### PR TITLE
Closes #2: Project Setup & Xcode Configuration

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,25 @@
+---
+name: Bug Report
+about: Report a defect or unexpected behavior
+title: 'Bug: [Brief description]'
+labels: bug
+assignees: ''
+---
+
+## Description
+[Clear and concise description of what the bug is]
+
+## Steps to Reproduce
+1. [First step]
+2. [Second step]
+3. [Third step]
+...
+
+## Expected Behavior
+[What you expected to happen]
+
+## Actual Behavior
+[What actually happened]
+
+## Screenshots/Logs
+[If applicable, add screenshots, error logs, or stack traces]

--- a/.github/ISSUE_TEMPLATE/story.md
+++ b/.github/ISSUE_TEMPLATE/story.md
@@ -1,0 +1,15 @@
+---
+name: User Story
+about: Product feature from user perspective
+labels: story
+---
+
+**User Story:**
+As a [role], I want [goal] so that [benefit]
+
+**Acceptance Criteria:**
+- [ ] Criterion 1
+- [ ] Criterion 2
+
+**Notes:**
+[Additional context]

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,18 @@
+---
+name: Technical Task
+about: Implementation task from story breakdown
+labels: task
+---
+
+**Description:**
+[What needs to be built]
+
+**Acceptance Criteria:**
+- [ ] Code implemented
+- [ ] Tests written (min 80% coverage)
+- [ ] Documentation updated
+
+**Technical Notes:**
+[Architecture decisions, APIs to use]
+
+**Story:** #[parent story number]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI Pipeline
+
+on:
+  pull_request:
+    branches: [main, develop]
+
+jobs:
+  build-test:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Build
+        run: xcodebuild build -scheme RSSReader -destination 'platform=macOS'
+      
+      - name: Test
+        run: xcodebuild test -scheme RSSReader -destination 'platform=macOS' \
+          -enableCodeCoverage YES
+      
+      - name: SwiftLint
+        run: swiftlint lint --strict
+      
+      - name: Coverage Report
+        run: xcrun xccov view --report --only-targets \
+          DerivedData/Logs/Test/*.xcresult

--- a/.github/workflows/label-automation.yml
+++ b/.github/workflows/label-automation.yml
@@ -1,0 +1,65 @@
+name: Issue Labeling
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label by Title
+        uses: actions/labeler@v4
+        with:
+          configuration-path: .github/labeler.yml
+```
+
+---
+
+### **Project Structure**
+```
+RSSReader/
+├── .github/
+│   ├── ISSUE_TEMPLATE/
+│   │   ├── story.md
+│   │   ├── task.md
+│   │   └── bug.md
+│   └── workflows/
+│       ├── ci.yml
+│       └── label-automation.yml
+├── docs/
+│   ├── architecture/
+│   │   └── feed-subscription.md
+│   ├── STANDARDS.md
+│   ├── CONVENTIONS.md
+│   └── agent-prompts/
+│       ├── architect.md
+│       ├── scrum-master.md
+│       ├── engineer.md
+│       └── qa.md
+├── RSSReader/
+│   ├── Models/
+│   ├── Views/
+│   ├── ViewModels/
+│   ├── Services/
+│   └── Utilities/
+├── RSSReaderTests/
+├── Package.swift
+├── .swiftlint.yml
+└── README.md
+```
+
+---
+
+## Agent Coordination Mechanisms
+
+### **1. GitHub Labels as State Machine**
+```
+Product Flow:
+[product] → [arch-review] → [ready-for-breakdown] → [ready-for-dev] → [in-progress] → [in-review] → [done]
+
+Agent Triggers:
+- Architect: Monitors issues with [arch-review]
+- Scrum Master: Monitors issues with [ready-for-breakdown]
+- Engineer: Monitors issues with [ready-for-dev]
+- QA: Monitors PRs with [ready-for-review]

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,36 @@
+# Xcode
+DerivedData/
+*.xcuserdata
+*.xcworkspacedata
+xcuserdata/
+
+# Swift Package Manager
+.build/
+.swiftpm/
+Package.resolved
+
+# macOS
+.DS_Store
+*.swp
+*~
+
+# IDE
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+*.xccheckout
+*.moved-aside
+*.hmap
+*.ipa
+*.dSYM.zip
+*.dSYM
+
+# Environment
+.env
+*.xcconfig
+!default.xcconfig

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,145 @@
+# SwiftLint configuration for RSSReader
+# https://github.com/realm/SwiftLint
+
+# Paths to include
+included:
+  - RSSReader
+  - RSSReaderTests
+  - RSSReaderUITests
+
+# Paths to exclude
+excluded:
+  - .build
+  - DerivedData
+  - Packages
+
+# Rules
+disabled_rules:
+  - trailing_comma
+  - todo
+
+opt_in_rules:
+  - closure_end_indentation
+  - closure_spacing
+  - collection_alignment
+  - contains_over_filter_count
+  - contains_over_filter_is_empty
+  - contains_over_first_not_nil
+  - contains_over_range_nil_comparison
+  - convenience_type
+  - discouraged_object_literal
+  - empty_collection_literal
+  - empty_count
+  - empty_string
+  - enum_case_associated_values_count
+  - explicit_init
+  - extension_access_modifier
+  - fallthrough
+  - fatal_error_message
+  - file_name_no_space
+  - first_where
+  - flatmap_over_map_reduce
+  - force_unwrapping
+  - identical_operands
+  - implicitly_unwrapped_optional
+  - joined_default_parameter
+  - last_where
+  - legacy_multiple
+  - literal_expression_end_indentation
+  - lower_acl_than_parent
+  - modifier_order
+  - multiline_arguments
+  - multiline_function_chains
+  - multiline_literal_brackets
+  - multiline_parameters
+  - operator_usage_whitespace
+  - overridden_super_call
+  - override_in_extension
+  - pattern_matching_keywords
+  - prefer_self_in_static_references
+  - prefer_self_type_over_type_of_self
+  - prefer_zero_over_explicit_init
+  - private_action
+  - private_outlet
+  - prohibited_super_call
+  - reduce_into
+  - redundant_nil_coalescing
+  - redundant_type_annotation
+  - return_value_from_void_function
+  - sorted_first_last
+  - static_operator
+  - toggle_bool
+  - unavailable_function
+  - unneeded_parentheses_in_closure_argument
+  - unowned_variable_capture
+  - unused_declaration
+  - unused_import
+  - vertical_parameter_alignment_on_call
+  - vertical_whitespace_closing_braces
+  - vertical_whitespace_opening_braces
+  - yoda_condition
+
+# Line length
+line_length:
+  warning: 100
+  error: 120
+  ignores_comments: true
+  ignores_urls: true
+  ignores_interpolated_strings: true
+
+# File length
+file_length:
+  warning: 400
+  error: 500
+
+# Function body length
+function_body_length:
+  warning: 40
+  error: 60
+
+# Type body length
+type_body_length:
+  warning: 250
+  error: 350
+
+# Cyclomatic complexity
+cyclomatic_complexity:
+  warning: 10
+  error: 15
+
+# Identifier name
+identifier_name:
+  min_length:
+    warning: 2
+    error: 1
+  max_length:
+    warning: 50
+    error: 60
+  allowed_symbols:
+    - _
+  excluded:
+    - id
+    - x
+    - y
+    - i
+    - j
+    - n
+
+# Type name
+type_name:
+  min_length:
+    warning: 3
+    error: 2
+  max_length:
+    warning: 50
+    error: 60
+
+# Nesting
+nesting:
+  type_level:
+    warning: 2
+  function_level:
+    warning: 3
+
+# Reporter
+reporter: xcode

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,49 @@
+// swift-tools-version: 6.0
+// The swift-tools-version declares the minimum version of Swift Package Manager
+// required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "RSSReader",
+    platforms: [
+        .macOS(.v14)
+    ],
+    products: [
+        .library(
+            name: "RSSReaderLib",
+            targets: ["RSSReader"]
+        )
+    ],
+    dependencies: [
+        .package(
+            url: "https://github.com/swiftlang/swift-testing.git",
+            branch: "main"
+        )
+    ],
+    targets: [
+        .target(
+            name: "RSSReader",
+            path: "RSSReader",
+            exclude: [
+                "Info.plist",
+                "RSSReader.entitlements",
+                "App/RSSReaderApp.swift"
+            ],
+            swiftSettings: [
+                .swiftLanguageMode(.v5)
+            ]
+        ),
+        .testTarget(
+            name: "RSSReaderTests",
+            dependencies: [
+                "RSSReader",
+                .product(name: "Testing", package: "swift-testing")
+            ],
+            path: "RSSReaderTests",
+            swiftSettings: [
+                .swiftLanguageMode(.v5)
+            ]
+        )
+    ]
+)

--- a/RSSReader.xcodeproj/project.pbxproj
+++ b/RSSReader.xcodeproj/project.pbxproj
@@ -1,0 +1,748 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		/* App Sources */
+		A1000001 /* RSSReaderApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000001 /* RSSReaderApp.swift */; };
+		A1000002 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000002 /* AppState.swift */; };
+		A1000003 /* KeyboardCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000003 /* KeyboardCommands.swift */; };
+
+		/* Views */
+		A1000010 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000010 /* ContentView.swift */; };
+		A1000011 /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000011 /* MainView.swift */; };
+		A1000012 /* AuthenticationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000012 /* AuthenticationView.swift */; };
+
+		/* Models */
+		A1000020 /* FeedlyUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000020 /* FeedlyUser.swift */; };
+		A1000021 /* AppError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000021 /* AppError.swift */; };
+		A1000022 /* AuthenticationToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000022 /* AuthenticationToken.swift */; };
+		A1000023 /* Category.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000023 /* Category.swift */; };
+		A1000024 /* Feed.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000024 /* Feed.swift */; };
+		A1000025 /* Subscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000025 /* Subscription.swift */; };
+		A1000026 /* Article.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000026 /* Article.swift */; };
+		A1000027 /* APIResponses.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000027 /* APIResponses.swift */; };
+
+		/* Services */
+		A1000050 /* ServiceProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000050 /* ServiceProtocols.swift */; };
+
+		/* Utilities */
+		A1000060 /* StringExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000060 /* StringExtensions.swift */; };
+
+		/* Unit Tests */
+		A1000030 /* AppErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000030 /* AppErrorTests.swift */; };
+		A1000031 /* FeedlyUserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000031 /* FeedlyUserTests.swift */; };
+
+		/* UI Tests */
+		A1000040 /* RSSReaderUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000040 /* RSSReaderUITests.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		A3000001 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A4000000 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A5000001;
+			remoteInfo = RSSReader;
+		};
+		A3000002 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A4000000 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A5000001;
+			remoteInfo = RSSReader;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		/* App Sources */
+		A2000001 /* RSSReaderApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSSReaderApp.swift; sourceTree = "<group>"; };
+		A2000002 /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
+		A2000003 /* KeyboardCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardCommands.swift; sourceTree = "<group>"; };
+
+		/* Views */
+		A2000010 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		A2000011 /* MainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainView.swift; sourceTree = "<group>"; };
+		A2000012 /* AuthenticationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationView.swift; sourceTree = "<group>"; };
+
+		/* Models */
+		A2000020 /* FeedlyUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedlyUser.swift; sourceTree = "<group>"; };
+		A2000021 /* AppError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppError.swift; sourceTree = "<group>"; };
+		A2000022 /* AuthenticationToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationToken.swift; sourceTree = "<group>"; };
+		A2000023 /* Category.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Category.swift; sourceTree = "<group>"; };
+		A2000024 /* Feed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feed.swift; sourceTree = "<group>"; };
+		A2000025 /* Subscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Subscription.swift; sourceTree = "<group>"; };
+		A2000026 /* Article.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Article.swift; sourceTree = "<group>"; };
+		A2000027 /* APIResponses.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIResponses.swift; sourceTree = "<group>"; };
+
+		/* Services */
+		A2000050 /* ServiceProtocols.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceProtocols.swift; sourceTree = "<group>"; };
+
+		/* Utilities */
+		A2000060 /* StringExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringExtensions.swift; sourceTree = "<group>"; };
+
+		/* ViewModels */
+		A2000070 /* ViewModelPlaceholder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelPlaceholder.swift; sourceTree = "<group>"; };
+
+		/* Unit Tests */
+		A2000030 /* AppErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppErrorTests.swift; sourceTree = "<group>"; };
+		A2000031 /* FeedlyUserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedlyUserTests.swift; sourceTree = "<group>"; };
+
+		/* UI Tests */
+		A2000040 /* RSSReaderUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSSReaderUITests.swift; sourceTree = "<group>"; };
+
+		/* Products */
+		A2100001 /* RSSReader.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RSSReader.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		A2100002 /* RSSReaderTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RSSReaderTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		A2100003 /* RSSReaderUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RSSReaderUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		A6000001 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A6000002 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A6000003 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		A7000000 = {
+			isa = PBXGroup;
+			children = (
+				A7000001 /* RSSReader */,
+				A7000002 /* RSSReaderTests */,
+				A7000003 /* RSSReaderUITests */,
+				A7000004 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		A7000001 /* RSSReader */ = {
+			isa = PBXGroup;
+			children = (
+				A7000010 /* App */,
+				A7000011 /* Models */,
+				A7000012 /* Views */,
+				A7000013 /* ViewModels */,
+				A7000014 /* Services */,
+				A7000015 /* Utilities */,
+			);
+			path = RSSReader;
+			sourceTree = "<group>";
+		};
+		A7000002 /* RSSReaderTests */ = {
+			isa = PBXGroup;
+			children = (
+				A7000020 /* UnitTests */,
+				A7000021 /* IntegrationTests */,
+			);
+			path = RSSReaderTests;
+			sourceTree = "<group>";
+		};
+		A7000003 /* RSSReaderUITests */ = {
+			isa = PBXGroup;
+			children = (
+				A2000040 /* RSSReaderUITests.swift */,
+			);
+			path = RSSReaderUITests;
+			sourceTree = "<group>";
+		};
+		A7000004 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				A2100001 /* RSSReader.app */,
+				A2100002 /* RSSReaderTests.xctest */,
+				A2100003 /* RSSReaderUITests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		A7000010 /* App */ = {
+			isa = PBXGroup;
+			children = (
+				A2000001 /* RSSReaderApp.swift */,
+				A2000002 /* AppState.swift */,
+				A2000003 /* KeyboardCommands.swift */,
+			);
+			path = App;
+			sourceTree = "<group>";
+		};
+		A7000011 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				A2000020 /* FeedlyUser.swift */,
+				A2000021 /* AppError.swift */,
+				A2000022 /* AuthenticationToken.swift */,
+				A2000023 /* Category.swift */,
+				A2000024 /* Feed.swift */,
+				A2000025 /* Subscription.swift */,
+				A2000026 /* Article.swift */,
+				A2000027 /* APIResponses.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
+		A7000012 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				A2000010 /* ContentView.swift */,
+				A2000011 /* MainView.swift */,
+				A2000012 /* AuthenticationView.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
+		A7000013 /* ViewModels */ = {
+			isa = PBXGroup;
+			children = (
+				A2000070 /* ViewModelPlaceholder.swift */,
+			);
+			path = ViewModels;
+			sourceTree = "<group>";
+		};
+		A7000014 /* Services */ = {
+			isa = PBXGroup;
+			children = (
+				A2000050 /* ServiceProtocols.swift */,
+			);
+			path = Services;
+			sourceTree = "<group>";
+		};
+		A7000015 /* Utilities */ = {
+			isa = PBXGroup;
+			children = (
+				A2000060 /* StringExtensions.swift */,
+			);
+			path = Utilities;
+			sourceTree = "<group>";
+		};
+		A7000020 /* UnitTests */ = {
+			isa = PBXGroup;
+			children = (
+				A7000022 /* Models */,
+				A7000023 /* ViewModels */,
+				A7000024 /* Services */,
+			);
+			path = UnitTests;
+			sourceTree = "<group>";
+		};
+		A7000021 /* IntegrationTests */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = IntegrationTests;
+			sourceTree = "<group>";
+		};
+		A7000022 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				A2000030 /* AppErrorTests.swift */,
+				A2000031 /* FeedlyUserTests.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
+		A7000023 /* ViewModels */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = ViewModels;
+			sourceTree = "<group>";
+		};
+		A7000024 /* Services */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Services;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		A5000001 /* RSSReader */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A8000001 /* Build configuration list for PBXNativeTarget "RSSReader" */;
+			buildPhases = (
+				A9000001 /* Sources */,
+				A6000001 /* Frameworks */,
+				AA000001 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = RSSReader;
+			productName = RSSReader;
+			productReference = A2100001 /* RSSReader.app */;
+			productType = "com.apple.product-type.application";
+		};
+		A5000002 /* RSSReaderTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A8000002 /* Build configuration list for PBXNativeTarget "RSSReaderTests" */;
+			buildPhases = (
+				A9000002 /* Sources */,
+				A6000002 /* Frameworks */,
+				AA000002 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				A5000010 /* PBXTargetDependency */,
+			);
+			name = RSSReaderTests;
+			productName = RSSReaderTests;
+			productReference = A2100002 /* RSSReaderTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		A5000003 /* RSSReaderUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A8000003 /* Build configuration list for PBXNativeTarget "RSSReaderUITests" */;
+			buildPhases = (
+				A9000003 /* Sources */,
+				A6000003 /* Frameworks */,
+				AA000003 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				A5000011 /* PBXTargetDependency */,
+			);
+			name = RSSReaderUITests;
+			productName = RSSReaderUITests;
+			productReference = A2100003 /* RSSReaderUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		A4000000 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1500;
+				LastUpgradeCheck = 1500;
+				TargetAttributes = {
+					A5000001 = {
+						CreatedOnToolsVersion = 15.0;
+					};
+					A5000002 = {
+						CreatedOnToolsVersion = 15.0;
+						TestTargetID = A5000001;
+					};
+					A5000003 = {
+						CreatedOnToolsVersion = 15.0;
+						TestTargetID = A5000001;
+					};
+				};
+			};
+			buildConfigurationList = A8000000 /* Build configuration list for PBXProject "RSSReader" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = A7000000;
+			productRefGroup = A7000004 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				A5000001 /* RSSReader */,
+				A5000002 /* RSSReaderTests */,
+				A5000003 /* RSSReaderUITests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		AA000001 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		AA000002 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		AA000003 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		A9000001 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A1000001 /* RSSReaderApp.swift in Sources */,
+				A1000002 /* AppState.swift in Sources */,
+				A1000003 /* KeyboardCommands.swift in Sources */,
+				A1000010 /* ContentView.swift in Sources */,
+				A1000011 /* MainView.swift in Sources */,
+				A1000012 /* AuthenticationView.swift in Sources */,
+				A1000020 /* FeedlyUser.swift in Sources */,
+				A1000021 /* AppError.swift in Sources */,
+				A1000022 /* AuthenticationToken.swift in Sources */,
+				A1000023 /* Category.swift in Sources */,
+				A1000024 /* Feed.swift in Sources */,
+				A1000025 /* Subscription.swift in Sources */,
+				A1000026 /* Article.swift in Sources */,
+				A1000027 /* APIResponses.swift in Sources */,
+				A1000050 /* ServiceProtocols.swift in Sources */,
+				A1000060 /* StringExtensions.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A9000002 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A1000030 /* AppErrorTests.swift in Sources */,
+				A1000031 /* FeedlyUserTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A9000003 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A1000040 /* RSSReaderUITests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		A5000010 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A5000001 /* RSSReader */;
+			targetProxy = A3000001 /* PBXContainerItemProxy */;
+		};
+		A5000011 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A5000001 /* RSSReader */;
+			targetProxy = A3000002 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		/* Project Debug */
+		AB000001 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		/* Project Release */
+		AB000002 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = macosx;
+				SWIFT_COMPILATION_MODE = wholemodule;
+			};
+			name = Release;
+		};
+		/* RSSReader Debug */
+		AB000011 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = RSSReader/RSSReader.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = RSSReader/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "RSS Reader";
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.news";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.rssreader.app;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		/* RSSReader Release */
+		AB000012 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = RSSReader/RSSReader.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = RSSReader/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "RSS Reader";
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.news";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.rssreader.app;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		/* RSSReaderTests Debug */
+		AB000021 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.rssreader.tests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/RSSReader.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/RSSReader";
+			};
+			name = Debug;
+		};
+		/* RSSReaderTests Release */
+		AB000022 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.rssreader.tests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/RSSReader.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/RSSReader";
+			};
+			name = Release;
+		};
+		/* RSSReaderUITests Debug */
+		AB000031 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.rssreader.uitests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TEST_TARGET_NAME = RSSReader;
+			};
+			name = Debug;
+		};
+		/* RSSReaderUITests Release */
+		AB000032 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.rssreader.uitests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TEST_TARGET_NAME = RSSReader;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		A8000000 /* Build configuration list for PBXProject "RSSReader" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AB000001 /* Debug */,
+				AB000002 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A8000001 /* Build configuration list for PBXNativeTarget "RSSReader" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AB000011 /* Debug */,
+				AB000012 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A8000002 /* Build configuration list for PBXNativeTarget "RSSReaderTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AB000021 /* Debug */,
+				AB000022 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A8000003 /* Build configuration list for PBXNativeTarget "RSSReaderUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AB000031 /* Debug */,
+				AB000032 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = A4000000 /* Project object */;
+}

--- a/RSSReader/App/AppState.swift
+++ b/RSSReader/App/AppState.swift
@@ -1,0 +1,29 @@
+//
+//  AppState.swift
+//  RSSReader
+//
+//  Created on 2026-01-28.
+//
+
+import Combine
+import Foundation
+
+/// Global application state managing authentication and user session.
+@MainActor
+final class AppState: ObservableObject {
+    /// Whether the user is currently authenticated with Feedly.
+    @Published var isAuthenticated = false
+
+    /// The currently logged-in user, if any.
+    @Published var currentUser: FeedlyUser?
+
+    /// Global error state for critical errors that need user attention.
+    @Published var error: AppError?
+
+    /// Clears the current session and resets to unauthenticated state.
+    func logout() {
+        isAuthenticated = false
+        currentUser = nil
+        error = nil
+    }
+}

--- a/RSSReader/App/KeyboardCommands.swift
+++ b/RSSReader/App/KeyboardCommands.swift
@@ -1,0 +1,56 @@
+//
+//  KeyboardCommands.swift
+//  RSSReader
+//
+//  Created on 2026-01-28.
+//
+
+import SwiftUI
+
+/// Keyboard shortcuts for the application menu.
+struct KeyboardCommands: Commands {
+    var body: some Commands {
+        CommandGroup(replacing: .newItem) {}
+
+        CommandMenu("Navigation") {
+            Button("Next Unread") {
+                NotificationCenter.default.post(name: .nextUnread, object: nil)
+            }
+            .keyboardShortcut("n", modifiers: [])
+
+            Button("Previous Article") {
+                NotificationCenter.default.post(name: .previousArticle, object: nil)
+            }
+            .keyboardShortcut(.upArrow, modifiers: [])
+
+            Button("Next Article") {
+                NotificationCenter.default.post(name: .nextArticle, object: nil)
+            }
+            .keyboardShortcut(.downArrow, modifiers: [])
+
+            Divider()
+
+            Button("Refresh") {
+                NotificationCenter.default.post(name: .refresh, object: nil)
+            }
+            .keyboardShortcut("r", modifiers: [.command])
+
+            Divider()
+
+            Button("Open in Safari") {
+                NotificationCenter.default.post(name: .openInSafari, object: nil)
+            }
+            .keyboardShortcut(.return, modifiers: [])
+        }
+    }
+}
+
+// MARK: - Notification Names
+
+extension Notification.Name {
+    static let nextUnread = Notification.Name("nextUnread")
+    static let previousArticle = Notification.Name("previousArticle")
+    static let nextArticle = Notification.Name("nextArticle")
+    static let refresh = Notification.Name("refresh")
+    static let openInSafari = Notification.Name("openInSafari")
+}

--- a/RSSReader/App/RSSReaderApp.swift
+++ b/RSSReader/App/RSSReaderApp.swift
@@ -1,0 +1,23 @@
+//
+//  RSSReaderApp.swift
+//  RSSReader
+//
+//  Created on 2026-01-28.
+//
+
+import SwiftUI
+
+@main
+struct RSSReaderApp: App {
+    @StateObject private var appState = AppState()
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environmentObject(appState)
+        }
+        .commands {
+            KeyboardCommands()
+        }
+    }
+}

--- a/RSSReader/Info.plist
+++ b/RSSReader/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>com.rssreader.oauth</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>feedlyreader</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<false/>
+	</dict>
+</dict>
+</plist>

--- a/RSSReader/Models/APIResponses.swift
+++ b/RSSReader/Models/APIResponses.swift
@@ -1,0 +1,41 @@
+//
+//  APIResponses.swift
+//  RSSReader
+//
+//  Created on 2026-01-28.
+//
+
+import Foundation
+
+/// Response from the Feedly stream contents endpoint.
+struct StreamContents: Codable {
+    let id: String
+    let title: String?
+    let direction: String?
+    let continuation: String?
+    let updated: Date?
+    // Note: items will be parsed as Article objects separately
+    // since Article has custom logic beyond Codable
+}
+
+/// Individual unread count for a stream/feed.
+struct UnreadCount: Codable, Equatable {
+    let id: String
+    let count: Int
+    let updated: Date?
+}
+
+/// Response from the Feedly unread counts endpoint.
+struct UnreadCountsResponse: Codable {
+    let unreadcounts: [UnreadCount]
+    let updated: Date?
+}
+
+/// Session cache for in-memory storage of current state.
+struct SessionCache {
+    var categories: [Category] = []
+    var articles: [String: Article] = [:]
+    var lastRefresh: Date?
+    var selectedCategoryId: String?
+    var selectedArticleId: String?
+}

--- a/RSSReader/Models/AppError.swift
+++ b/RSSReader/Models/AppError.swift
@@ -1,0 +1,57 @@
+//
+//  AppError.swift
+//  RSSReader
+//
+//  Created on 2026-01-28.
+//
+
+import Foundation
+
+/// Application-specific errors with user-friendly messages.
+enum AppError: LocalizedError, Identifiable, Equatable {
+    case authenticationFailed(String)
+    case networkError(String)
+    case apiError(statusCode: Int, message: String)
+    case invalidResponse
+    case rateLimitExceeded
+    case tokenExpired
+    case noInternet
+
+    var id: String {
+        errorDescription ?? UUID().uuidString
+    }
+
+    var errorDescription: String? {
+        switch self {
+        case .authenticationFailed(let message):
+            return "Authentication failed: \(message)"
+        case .networkError(let message):
+            return "Network error: \(message)"
+        case .apiError(let code, let message):
+            return "Feedly API error (\(code)): \(message)"
+        case .invalidResponse:
+            return "Invalid response from server"
+        case .rateLimitExceeded:
+            return "Rate limit exceeded. Please try again later."
+        case .tokenExpired:
+            return "Session expired. Please log in again."
+        case .noInternet:
+            return "No internet connection. Unable to connect to Feedly."
+        }
+    }
+
+    var recoverySuggestion: String? {
+        switch self {
+        case .noInternet:
+            return "Check your internet connection and try again."
+        case .tokenExpired:
+            return "Please log in again to continue."
+        case .rateLimitExceeded:
+            return "Wait a few minutes before trying again."
+        case .authenticationFailed:
+            return "Please try signing in again."
+        default:
+            return "Please try again later."
+        }
+    }
+}

--- a/RSSReader/Models/Article.swift
+++ b/RSSReader/Models/Article.swift
@@ -1,0 +1,86 @@
+//
+//  Article.swift
+//  RSSReader
+//
+//  Created on 2026-01-28.
+//
+
+import Foundation
+
+/// Represents an article/entry from a Feedly stream.
+struct Article: Identifiable, Hashable {
+    let id: String
+    let title: String
+    let author: String?
+    let published: Date
+    let updated: Date?
+    let summary: ArticleContent?
+    let content: ArticleContent?
+    let origin: Origin
+    let canonical: [Link]?
+    let alternate: [Link]?
+    let visual: Visual?
+    var isRead: Bool
+    let engagement: Int?
+    let keywords: [String]?
+
+    /// Formatted date string for display.
+    var displayDate: String {
+        published.formatted(date: .abbreviated, time: .shortened)
+    }
+
+    /// The primary URL for this article.
+    var primaryLink: URL? {
+        alternate?.first?.href ?? canonical?.first?.href
+    }
+
+    /// Thumbnail image URL if available.
+    var thumbnailUrl: URL? {
+        visual?.url
+    }
+
+    /// Plain text content with HTML tags stripped.
+    var plainTextContent: String {
+        let rawContent = content?.content ?? summary?.content ?? ""
+        return rawContent.stripHTML()
+    }
+
+    // MARK: - Hashable
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
+
+    static func == (lhs: Article, rhs: Article) -> Bool {
+        lhs.id == rhs.id
+    }
+
+    // MARK: - Nested Types
+
+    /// Article HTML content with optional text direction.
+    struct ArticleContent: Codable, Hashable {
+        let content: String
+        let direction: String?
+    }
+
+    /// The source feed for this article.
+    struct Origin: Codable, Hashable {
+        let streamId: String
+        let title: String
+        let htmlUrl: URL?
+    }
+
+    /// A link associated with the article.
+    struct Link: Codable, Hashable {
+        let href: URL
+        let type: String?
+    }
+
+    /// Visual/thumbnail image for the article.
+    struct Visual: Codable, Hashable {
+        let url: URL
+        let width: Int?
+        let height: Int?
+        let contentType: String?
+    }
+}

--- a/RSSReader/Models/AuthenticationToken.swift
+++ b/RSSReader/Models/AuthenticationToken.swift
@@ -1,0 +1,46 @@
+//
+//  AuthenticationToken.swift
+//  RSSReader
+//
+//  Created on 2026-01-28.
+//
+
+import Foundation
+
+/// Represents an OAuth authentication token from Feedly.
+struct AuthenticationToken: Codable, Equatable {
+    let accessToken: String
+    let refreshToken: String?
+    let tokenType: String
+    let expiresIn: TimeInterval
+    let scope: String?
+
+    /// The date when this token was created.
+    let createdAt: Date
+
+    /// The date when this token expires.
+    var expirationDate: Date {
+        createdAt.addingTimeInterval(expiresIn)
+    }
+
+    /// Whether the token has expired.
+    var isExpired: Bool {
+        Date() >= expirationDate
+    }
+
+    init(
+        accessToken: String,
+        refreshToken: String? = nil,
+        tokenType: String = "Bearer",
+        expiresIn: TimeInterval = 3600,
+        scope: String? = nil,
+        createdAt: Date = Date()
+    ) {
+        self.accessToken = accessToken
+        self.refreshToken = refreshToken
+        self.tokenType = tokenType
+        self.expiresIn = expiresIn
+        self.scope = scope
+        self.createdAt = createdAt
+    }
+}

--- a/RSSReader/Models/Category.swift
+++ b/RSSReader/Models/Category.swift
@@ -1,0 +1,33 @@
+//
+//  Category.swift
+//  RSSReader
+//
+//  Created on 2026-01-28.
+//
+
+import Foundation
+
+/// Represents a Feedly category containing grouped feeds.
+struct Category: Identifiable, Hashable {
+    let id: String
+    let label: String
+    var unreadCount: Int
+    var feeds: [Feed]
+
+    /// Display-friendly name, stripping the Feedly user prefix.
+    var displayName: String {
+        label.replacingOccurrences(
+            of: "user/\\w+/category/",
+            with: "",
+            options: .regularExpression
+        )
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
+
+    static func == (lhs: Category, rhs: Category) -> Bool {
+        lhs.id == rhs.id
+    }
+}

--- a/RSSReader/Models/Feed.swift
+++ b/RSSReader/Models/Feed.swift
@@ -1,0 +1,28 @@
+//
+//  Feed.swift
+//  RSSReader
+//
+//  Created on 2026-01-28.
+//
+
+import Foundation
+
+/// Represents an RSS feed subscription in Feedly.
+struct Feed: Identifiable, Hashable, Codable {
+    let id: String
+    let title: String
+    let website: URL?
+    let iconUrl: URL?
+    let description: String?
+    var unreadCount: Int
+    let visualUrl: URL?
+    let updated: Date?
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
+
+    static func == (lhs: Feed, rhs: Feed) -> Bool {
+        lhs.id == rhs.id
+    }
+}

--- a/RSSReader/Models/FeedlyUser.swift
+++ b/RSSReader/Models/FeedlyUser.swift
@@ -1,0 +1,24 @@
+//
+//  FeedlyUser.swift
+//  RSSReader
+//
+//  Created on 2026-01-28.
+//
+
+import Foundation
+
+/// Represents a Feedly user profile.
+struct FeedlyUser: Codable, Identifiable, Equatable {
+    let id: String
+    let email: String
+    let fullName: String?
+    let picture: URL?
+    let givenName: String?
+    let familyName: String?
+    let locale: String?
+
+    /// Display name, falling back to email if full name is unavailable.
+    var displayName: String {
+        fullName ?? email
+    }
+}

--- a/RSSReader/Models/Subscription.swift
+++ b/RSSReader/Models/Subscription.swift
@@ -1,0 +1,24 @@
+//
+//  Subscription.swift
+//  RSSReader
+//
+//  Created on 2026-01-28.
+//
+
+import Foundation
+
+/// Represents a Feedly subscription with category associations.
+struct Subscription: Identifiable, Codable, Equatable {
+    let id: String
+    let title: String
+    let categories: [CategoryReference]
+    let website: URL?
+    let iconUrl: URL?
+    let visualUrl: URL?
+
+    /// Lightweight reference to a category from a subscription response.
+    struct CategoryReference: Codable, Equatable {
+        let id: String
+        let label: String
+    }
+}

--- a/RSSReader/RSSReader.entitlements
+++ b/RSSReader/RSSReader.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+</dict>
+</plist>

--- a/RSSReader/Services/ServiceProtocols.swift
+++ b/RSSReader/Services/ServiceProtocols.swift
@@ -1,0 +1,71 @@
+//
+//  ServiceProtocols.swift
+//  RSSReader
+//
+//  Created on 2026-01-28.
+//
+
+import Foundation
+
+// MARK: - Feedly API Service Protocol
+
+/// Protocol for interacting with the Feedly API.
+protocol FeedlyAPIServiceProtocol {
+    // Authentication
+    func getAuthorizationURL() -> URL
+    func exchangeCodeForToken(code: String) async throws -> AuthenticationToken
+    func refreshToken(refreshToken: String) async throws -> AuthenticationToken
+
+    // User Profile
+    func getCurrentUser() async throws -> FeedlyUser
+
+    // Subscriptions & Categories
+    func getSubscriptions() async throws -> [Subscription]
+    func getUnreadCounts() async throws -> [UnreadCount]
+
+    // Articles
+    func getStreamContents(
+        streamId: String,
+        unreadOnly: Bool,
+        newerThan: Date?,
+        continuation: String?
+    ) async throws -> StreamContents
+
+    // Mark as read
+    func markArticleAsRead(articleId: String) async throws
+    func markArticlesAsRead(articleIds: [String]) async throws
+}
+
+// MARK: - Authentication Service Protocol
+
+/// Protocol for managing OAuth 2.0 authentication.
+protocol AuthenticationServiceProtocol {
+    var isAuthenticated: Bool { get }
+    var currentUser: FeedlyUser? { get }
+
+    func startOAuthFlow() async throws -> URL
+    func handleCallback(url: URL) async throws -> FeedlyUser
+    func logout() async throws
+    func refreshTokenIfNeeded() async throws
+}
+
+// MARK: - Cache Service Protocol
+
+/// Protocol for in-memory session caching.
+protocol CacheServiceProtocol {
+    func cacheArticles(_ articles: [Article])
+    func getArticle(id: String) -> Article?
+    func updateArticleReadStatus(id: String, isRead: Bool)
+    func clearCache()
+    func getCachedCategories() -> [Category]
+    func cacheCategories(_ categories: [Category])
+}
+
+// MARK: - Keychain Service Protocol
+
+/// Protocol for secure token storage.
+protocol KeychainServiceProtocol {
+    func save(token: AuthenticationToken) throws
+    func retrieveToken() throws -> AuthenticationToken?
+    func deleteToken() throws
+}

--- a/RSSReader/Utilities/StringExtensions.swift
+++ b/RSSReader/Utilities/StringExtensions.swift
@@ -1,0 +1,39 @@
+//
+//  StringExtensions.swift
+//  RSSReader
+//
+//  Created on 2026-01-28.
+//
+
+import Foundation
+
+extension String {
+    /// Strips HTML tags from a string, returning plain text content.
+    func stripHTML() -> String {
+        guard let data = self.data(using: .utf8) else {
+            return self
+        }
+
+        let options: [NSAttributedString.DocumentReadingOptionKey: Any] = [
+            .documentType: NSAttributedString.DocumentType.html,
+            .characterEncoding: String.Encoding.utf8.rawValue
+        ]
+
+        if let attributedString = try? NSAttributedString(
+            data: data,
+            options: options,
+            documentAttributes: nil
+        ) {
+            return attributedString.string
+        }
+
+        // Fallback: basic regex-based HTML stripping
+        return self
+            .replacingOccurrences(
+                of: "<[^>]+>",
+                with: "",
+                options: .regularExpression
+            )
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/RSSReader/ViewModels/ViewModelPlaceholder.swift
+++ b/RSSReader/ViewModels/ViewModelPlaceholder.swift
@@ -1,0 +1,11 @@
+//
+//  ViewModelPlaceholder.swift
+//  RSSReader
+//
+//  Created on 2026-01-28.
+//
+
+// ViewModels will be implemented in subsequent stories:
+// - FeedViewModel (#8)
+// - ArticleListViewModel (#9)
+// - ArticleDetailViewModel (#13)

--- a/RSSReader/Views/AuthenticationView.swift
+++ b/RSSReader/Views/AuthenticationView.swift
@@ -1,0 +1,84 @@
+//
+//  AuthenticationView.swift
+//  RSSReader
+//
+//  Created on 2026-01-28.
+//
+
+import SwiftUI
+
+/// Authentication view for Feedly OAuth login.
+struct AuthenticationView: View {
+    @EnvironmentObject var appState: AppState
+    @State private var isLoading = false
+    @State private var errorMessage: String?
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Spacer()
+
+            // App icon and title
+            VStack(spacing: 16) {
+                Image(systemName: "newspaper")
+                    .font(.system(size: 64))
+                    .foregroundStyle(.blue)
+
+                Text("RSS Reader")
+                    .font(.largeTitle)
+                    .fontWeight(.bold)
+
+                Text("A native macOS RSS reader powered by Feedly")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            // Login section
+            VStack(spacing: 16) {
+                if isLoading {
+                    ProgressView()
+                        .progressViewStyle(.circular)
+                        .scaleEffect(1.5)
+                    Text("Authenticating...")
+                        .foregroundStyle(.secondary)
+                } else {
+                    Button {
+                        signInWithFeedly()
+                    } label: {
+                        HStack {
+                            Image(systemName: "person.badge.key")
+                            Text("Sign in with Feedly")
+                        }
+                        .frame(minWidth: 200)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.large)
+                }
+
+                if let errorMessage {
+                    Text(errorMessage)
+                        .foregroundStyle(.red)
+                        .font(.caption)
+                        .multilineTextAlignment(.center)
+                        .frame(maxWidth: 300)
+                }
+            }
+
+            Spacer()
+
+            // Footer
+            Text("Keyboard-driven RSS reading experience")
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+        }
+        .frame(minWidth: 400, minHeight: 300)
+        .padding(40)
+    }
+
+    private func signInWithFeedly() {
+        isLoading = true
+        errorMessage = nil
+        // OAuth flow will be implemented in a later story
+    }
+}

--- a/RSSReader/Views/ContentView.swift
+++ b/RSSReader/Views/ContentView.swift
@@ -1,0 +1,23 @@
+//
+//  ContentView.swift
+//  RSSReader
+//
+//  Created on 2026-01-28.
+//
+
+import SwiftUI
+
+/// Root content view that switches between authentication and main views.
+struct ContentView: View {
+    @EnvironmentObject var appState: AppState
+
+    var body: some View {
+        Group {
+            if appState.isAuthenticated {
+                MainView()
+            } else {
+                AuthenticationView()
+            }
+        }
+    }
+}

--- a/RSSReader/Views/MainView.swift
+++ b/RSSReader/Views/MainView.swift
@@ -1,0 +1,84 @@
+//
+//  MainView.swift
+//  RSSReader
+//
+//  Created on 2026-01-28.
+//
+
+import SwiftUI
+
+/// Main 3-pane layout view for authenticated users.
+struct MainView: View {
+    @EnvironmentObject var appState: AppState
+
+    var body: some View {
+        NavigationSplitView {
+            // Left sidebar - Categories & Feeds
+            SidebarPlaceholderView()
+                .frame(minWidth: 200, idealWidth: 250, maxWidth: 300)
+        } content: {
+            // Middle pane - Article List
+            ArticleListPlaceholderView()
+                .frame(minWidth: 300, idealWidth: 400)
+        } detail: {
+            // Right pane - Article Content
+            ArticleDetailPlaceholderView()
+                .frame(minWidth: 500)
+        }
+        .navigationSplitViewStyle(.balanced)
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    NotificationCenter.default.post(name: .refresh, object: nil)
+                } label: {
+                    Label("Refresh", systemImage: "arrow.clockwise")
+                }
+                .keyboardShortcut("r", modifiers: [.command])
+            }
+        }
+    }
+}
+
+// MARK: - Placeholder Views
+
+/// Placeholder for the sidebar view until fully implemented.
+struct SidebarPlaceholderView: View {
+    var body: some View {
+        VStack {
+            Image(systemName: "folder")
+                .font(.largeTitle)
+                .foregroundStyle(.secondary)
+            Text("Categories & Feeds")
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+/// Placeholder for the article list view until fully implemented.
+struct ArticleListPlaceholderView: View {
+    var body: some View {
+        VStack {
+            Image(systemName: "list.bullet")
+                .font(.largeTitle)
+                .foregroundStyle(.secondary)
+            Text("Article List")
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+/// Placeholder for the article detail view until fully implemented.
+struct ArticleDetailPlaceholderView: View {
+    var body: some View {
+        VStack {
+            Image(systemName: "doc.text")
+                .font(.largeTitle)
+                .foregroundStyle(.secondary)
+            Text("Select an article to read")
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}

--- a/RSSReaderTests/IntegrationTests/IntegrationTestsPlaceholder.swift
+++ b/RSSReaderTests/IntegrationTests/IntegrationTestsPlaceholder.swift
@@ -1,0 +1,8 @@
+//
+//  IntegrationTestsPlaceholder.swift
+//  RSSReaderTests
+//
+//  Created on 2026-01-28.
+//
+
+// Integration tests will be added in story #22.

--- a/RSSReaderTests/UnitTests/Models/AppErrorTests.swift
+++ b/RSSReaderTests/UnitTests/Models/AppErrorTests.swift
@@ -1,0 +1,147 @@
+//
+//  AppErrorTests.swift
+//  RSSReaderTests
+//
+//  Created on 2026-01-28.
+//
+
+import Testing
+@testable import RSSReader
+
+@Suite("AppError Tests")
+struct AppErrorTests {
+
+    // MARK: - Error Description Tests
+
+    @Test("Authentication failed error description")
+    func authenticationFailedDescription() {
+        let error = AppError.authenticationFailed("Invalid credentials")
+        #expect(
+            error.errorDescription ==
+            "Authentication failed: Invalid credentials"
+        )
+    }
+
+    @Test("Network error description")
+    func networkErrorDescription() {
+        let error = AppError.networkError("Connection timeout")
+        #expect(
+            error.errorDescription ==
+            "Network error: Connection timeout"
+        )
+    }
+
+    @Test("API error description includes status code and message")
+    func apiErrorDescription() {
+        let error = AppError.apiError(
+            statusCode: 500,
+            message: "Internal server error"
+        )
+        #expect(
+            error.errorDescription ==
+            "Feedly API error (500): Internal server error"
+        )
+    }
+
+    @Test("Invalid response error description")
+    func invalidResponseDescription() {
+        let error = AppError.invalidResponse
+        #expect(error.errorDescription == "Invalid response from server")
+    }
+
+    @Test("Rate limit exceeded error description")
+    func rateLimitExceededDescription() {
+        let error = AppError.rateLimitExceeded
+        #expect(
+            error.errorDescription ==
+            "Rate limit exceeded. Please try again later."
+        )
+    }
+
+    @Test("Token expired error description")
+    func tokenExpiredDescription() {
+        let error = AppError.tokenExpired
+        #expect(
+            error.errorDescription ==
+            "Session expired. Please log in again."
+        )
+    }
+
+    @Test("No internet error description")
+    func noInternetDescription() {
+        let error = AppError.noInternet
+        #expect(
+            error.errorDescription ==
+            "No internet connection. Unable to connect to Feedly."
+        )
+    }
+
+    // MARK: - Recovery Suggestion Tests
+
+    @Test("No internet recovery suggestion")
+    func noInternetRecoverySuggestion() {
+        let error = AppError.noInternet
+        #expect(
+            error.recoverySuggestion ==
+            "Check your internet connection and try again."
+        )
+    }
+
+    @Test("Token expired recovery suggestion")
+    func tokenExpiredRecoverySuggestion() {
+        let error = AppError.tokenExpired
+        #expect(
+            error.recoverySuggestion ==
+            "Please log in again to continue."
+        )
+    }
+
+    @Test("Rate limit recovery suggestion")
+    func rateLimitExceededRecoverySuggestion() {
+        let error = AppError.rateLimitExceeded
+        #expect(
+            error.recoverySuggestion ==
+            "Wait a few minutes before trying again."
+        )
+    }
+
+    @Test("Auth failed recovery suggestion")
+    func authenticationFailedRecoverySuggestion() {
+        let error = AppError.authenticationFailed("Test")
+        #expect(
+            error.recoverySuggestion ==
+            "Please try signing in again."
+        )
+    }
+
+    @Test("Default recovery suggestion")
+    func defaultRecoverySuggestion() {
+        let error = AppError.invalidResponse
+        #expect(error.recoverySuggestion == "Please try again later.")
+    }
+
+    // MARK: - Identifiable Tests
+
+    @Test("Errors have identifiers")
+    func errorHasId() {
+        let error1 = AppError.noInternet
+        let error2 = AppError.tokenExpired
+        #expect(error1.id != error2.id)
+    }
+
+    // MARK: - Equatable Tests
+
+    @Test("Same errors are equal")
+    func errorEquality() {
+        let error1 = AppError.noInternet
+        let error2 = AppError.noInternet
+        #expect(error1 == error2)
+    }
+
+    @Test("Different errors are not equal")
+    func errorInequality() {
+        let error1 = AppError.noInternet
+        let error2 = AppError.tokenExpired
+        #expect(error1 != error2)
+    }
+}

--- a/RSSReaderTests/UnitTests/Models/FeedlyUserTests.swift
+++ b/RSSReaderTests/UnitTests/Models/FeedlyUserTests.swift
@@ -1,0 +1,161 @@
+//
+//  FeedlyUserTests.swift
+//  RSSReaderTests
+//
+//  Created on 2026-01-28.
+//
+
+import Foundation
+import Testing
+@testable import RSSReader
+
+@Suite("FeedlyUser Tests")
+struct FeedlyUserTests {
+
+    // MARK: - Display Name Tests
+
+    @Test("Display name returns fullName when available")
+    func displayNameReturnsFullNameWhenAvailable() {
+        let user = FeedlyUser(
+            id: "user123",
+            email: "test@example.com",
+            fullName: "John Doe",
+            picture: nil,
+            givenName: "John",
+            familyName: "Doe",
+            locale: "en_US"
+        )
+        #expect(user.displayName == "John Doe")
+    }
+
+    @Test("Display name falls back to email when fullName is nil")
+    func displayNameFallsBackToEmail() {
+        let user = FeedlyUser(
+            id: "user123",
+            email: "test@example.com",
+            fullName: nil,
+            picture: nil,
+            givenName: nil,
+            familyName: nil,
+            locale: nil
+        )
+        #expect(user.displayName == "test@example.com")
+    }
+
+    // MARK: - Codable Tests
+
+    @Test("User decodes from full JSON")
+    func userDecodingFromJSON() throws {
+        let json = """
+        {
+            "id": "user123",
+            "email": "test@example.com",
+            "fullName": "John Doe",
+            "picture": "https://example.com/avatar.png",
+            "givenName": "John",
+            "familyName": "Doe",
+            "locale": "en_US"
+        }
+        """
+
+        let data = json.data(using: .utf8)!
+        let user = try JSONDecoder().decode(FeedlyUser.self, from: data)
+
+        #expect(user.id == "user123")
+        #expect(user.email == "test@example.com")
+        #expect(user.fullName == "John Doe")
+        #expect(
+            user.picture == URL(string: "https://example.com/avatar.png")
+        )
+        #expect(user.givenName == "John")
+        #expect(user.familyName == "Doe")
+        #expect(user.locale == "en_US")
+    }
+
+    @Test("User decodes from minimal JSON")
+    func userDecodingWithMinimalJSON() throws {
+        let json = """
+        {
+            "id": "user123",
+            "email": "test@example.com"
+        }
+        """
+
+        let data = json.data(using: .utf8)!
+        let user = try JSONDecoder().decode(FeedlyUser.self, from: data)
+
+        #expect(user.id == "user123")
+        #expect(user.email == "test@example.com")
+        #expect(user.fullName == nil)
+        #expect(user.picture == nil)
+    }
+
+    @Test("User roundtrip encode/decode")
+    func userEncoding() throws {
+        let user = FeedlyUser(
+            id: "user123",
+            email: "test@example.com",
+            fullName: "John Doe",
+            picture: URL(string: "https://example.com/avatar.png"),
+            givenName: "John",
+            familyName: "Doe",
+            locale: "en_US"
+        )
+
+        let data = try JSONEncoder().encode(user)
+        let decoded = try JSONDecoder().decode(
+            FeedlyUser.self,
+            from: data
+        )
+
+        #expect(user == decoded)
+    }
+
+    // MARK: - Equatable Tests
+
+    @Test("Equal users are equal")
+    func userEquality() {
+        let user1 = FeedlyUser(
+            id: "user123",
+            email: "test@example.com",
+            fullName: "John Doe",
+            picture: nil,
+            givenName: nil,
+            familyName: nil,
+            locale: nil
+        )
+        let user2 = FeedlyUser(
+            id: "user123",
+            email: "test@example.com",
+            fullName: "John Doe",
+            picture: nil,
+            givenName: nil,
+            familyName: nil,
+            locale: nil
+        )
+        #expect(user1 == user2)
+    }
+
+    @Test("Different users are not equal")
+    func userInequality() {
+        let user1 = FeedlyUser(
+            id: "user123",
+            email: "test@example.com",
+            fullName: nil,
+            picture: nil,
+            givenName: nil,
+            familyName: nil,
+            locale: nil
+        )
+        let user2 = FeedlyUser(
+            id: "user456",
+            email: "other@example.com",
+            fullName: nil,
+            picture: nil,
+            givenName: nil,
+            familyName: nil,
+            locale: nil
+        )
+        #expect(user1 != user2)
+    }
+}

--- a/RSSReaderTests/UnitTests/Services/ServiceTestsPlaceholder.swift
+++ b/RSSReaderTests/UnitTests/Services/ServiceTestsPlaceholder.swift
@@ -1,0 +1,8 @@
+//
+//  ServiceTestsPlaceholder.swift
+//  RSSReaderTests
+//
+//  Created on 2026-01-28.
+//
+
+// Service tests will be added in subsequent stories.

--- a/RSSReaderTests/UnitTests/ViewModels/ViewModelTestsPlaceholder.swift
+++ b/RSSReaderTests/UnitTests/ViewModels/ViewModelTestsPlaceholder.swift
@@ -1,0 +1,8 @@
+//
+//  ViewModelTestsPlaceholder.swift
+//  RSSReaderTests
+//
+//  Created on 2026-01-28.
+//
+
+// ViewModel tests will be added in subsequent stories.

--- a/RSSReaderUITests/RSSReaderUITests.swift
+++ b/RSSReaderUITests/RSSReaderUITests.swift
@@ -1,0 +1,33 @@
+//
+//  RSSReaderUITests.swift
+//  RSSReaderUITests
+//
+//  Created on 2026-01-28.
+//
+
+import XCTest
+
+final class RSSReaderUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testAuthenticationViewDisplaysSignInButton() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        // Verify the sign in button exists
+        let signInButton = app.buttons["Sign in with Feedly"]
+        XCTAssertTrue(signInButton.waitForExistence(timeout: 5))
+    }
+
+    func testAppTitleDisplays() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        // Verify the app title is displayed
+        let title = app.staticTexts["RSS Reader"]
+        XCTAssertTrue(title.waitForExistence(timeout: 5))
+    }
+}


### PR DESCRIPTION
## Summary
- Set up the Xcode project targeting macOS 14.0+ (Sonoma) with SwiftUI app lifecycle
- Established complete MVVM folder structure: App, Models, Views, ViewModels, Services, Utilities
- Added SPM Package.swift for CLI-based build & test alongside the .xcodeproj for Xcode
- Configured SwiftLint with 100-char line limit and comprehensive rule set
- Created all core data models (FeedlyUser, AppError, AuthenticationToken, Category, Feed, Article, Subscription, APIResponses)
- Defined service protocols (FeedlyAPI, Authentication, Cache, Keychain) for protocol-oriented design
- Scaffolded placeholder views (ContentView, MainView with 3-pane layout, AuthenticationView)
- Set up keyboard commands infrastructure with NotificationCenter-based dispatch
- Configured Info.plist with `feedlyreader://` custom URL scheme for OAuth callback
- Added app sandbox entitlements with network client access
- Created unit test infrastructure using Swift Testing framework (22 tests passing)
- Set up UI test target for Xcode-based testing

## Test plan
- [x] `swift build` compiles successfully
- [x] `swift test` runs 22 unit tests — all passing
- [ ] Verify project opens correctly in Xcode (requires Xcode.app)
- [ ] Verify `xcodebuild test -scheme RSSReader` works (requires Xcode.app)

## Files Added
```
RSSReader/
├── App/          (RSSReaderApp, AppState, KeyboardCommands)
├── Models/       (8 model files - all core domain types)
├── Views/        (ContentView, MainView, AuthenticationView)
├── ViewModels/   (placeholder for upcoming stories)
├── Services/     (ServiceProtocols with all protocol definitions)
├── Utilities/    (StringExtensions with HTML stripping)
├── Info.plist    (OAuth URL scheme config)
└── RSSReader.entitlements

RSSReaderTests/
├── UnitTests/
│   ├── Models/   (AppErrorTests, FeedlyUserTests - 22 tests)
│   ├── ViewModels/
│   └── Services/
└── IntegrationTests/

RSSReaderUITests/
└── RSSReaderUITests.swift

.swiftlint.yml
Package.swift
.gitignore
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)