### PR TITLE
Closes #11: Sidebar View - Folders & Feeds Display

### DIFF
--- a/RSSReader/Models/CDFeed.swift
+++ b/RSSReader/Models/CDFeed.swift
@@ -29,6 +29,11 @@ public class CDFeed: NSManagedObject {
         }
         return articles.filter { !$0.isRead }.count
     }
+
+    /// Whether the feed has a fetch error.
+    public var hasError: Bool {
+        lastError != nil
+    }
 }
 
 // MARK: - Fetch Request

--- a/RSSReader/Models/CDFolder.swift
+++ b/RSSReader/Models/CDFolder.swift
@@ -24,6 +24,12 @@ public class CDFolder: NSManagedObject {
         }
         return feeds.reduce(0) { $0 + $1.unreadCount }
     }
+
+    /// Feeds sorted alphabetically by title for display.
+    public var sortedFeeds: [CDFeed] {
+        let feedSet = feeds as? Set<CDFeed> ?? []
+        return feedSet.sorted { $0.title < $1.title }
+    }
 }
 
 // MARK: - Fetch Request

--- a/RSSReader/ViewModels/SidebarViewModel.swift
+++ b/RSSReader/ViewModels/SidebarViewModel.swift
@@ -1,0 +1,103 @@
+//
+//  SidebarViewModel.swift
+//  RSSReader
+//
+//  Created on 2026-01-29.
+//
+
+import Combine
+import SwiftUI
+
+/// Represents a selectable item in the sidebar.
+enum SidebarSelection: Hashable {
+    case folder(UUID)
+    case feed(UUID)
+}
+
+/// ViewModel managing sidebar selection and folder
+/// expansion state.
+///
+/// Folder expansion defaults to expanded; only collapsed
+/// folder IDs are tracked, so new folders appear open
+/// automatically.
+@MainActor
+final class SidebarViewModel: ObservableObject {
+    @Published var selection: SidebarSelection?
+
+    /// IDs of explicitly collapsed folders. Folders not in
+    /// this set are treated as expanded.
+    @Published private(set) var collapsedFolders: Set<UUID> = []
+
+    // MARK: - Computed Selection Helpers
+
+    /// Returns the selected folder's UUID, or nil if a feed
+    /// (or nothing) is selected.
+    var selectedFolderId: UUID? {
+        if case .folder(let id) = selection { return id }
+        return nil
+    }
+
+    /// Returns the selected feed's UUID, or nil if a folder
+    /// (or nothing) is selected.
+    var selectedFeedId: UUID? {
+        if case .feed(let id) = selection { return id }
+        return nil
+    }
+
+    // MARK: - Selection Actions
+
+    func selectFolder(_ id: UUID) {
+        selection = .folder(id)
+    }
+
+    func selectFeed(_ id: UUID) {
+        selection = .feed(id)
+    }
+
+    func clearSelection() {
+        selection = nil
+    }
+
+    // MARK: - Expansion State
+
+    func isFolderExpanded(_ id: UUID) -> Bool {
+        !collapsedFolders.contains(id)
+    }
+
+    func setFolderExpanded(
+        _ id: UUID,
+        isExpanded: Bool
+    ) {
+        if isExpanded {
+            collapsedFolders.remove(id)
+        } else {
+            collapsedFolders.insert(id)
+        }
+    }
+
+    func toggleFolderExpansion(_ id: UUID) {
+        if collapsedFolders.contains(id) {
+            collapsedFolders.remove(id)
+        } else {
+            collapsedFolders.insert(id)
+        }
+    }
+
+    /// Creates a two-way binding for a folder's expansion
+    /// state, suitable for `DisclosureGroup(isExpanded:)`.
+    func expandedBinding(
+        for folderId: UUID
+    ) -> Binding<Bool> {
+        Binding(
+            get: { [weak self] in
+                self?.isFolderExpanded(folderId) ?? true
+            },
+            set: { [weak self] isExpanded in
+                self?.setFolderExpanded(
+                    folderId,
+                    isExpanded: isExpanded
+                )
+            }
+        )
+    }
+}

--- a/RSSReader/Views/MainView.swift
+++ b/RSSReader/Views/MainView.swift
@@ -13,9 +13,8 @@ struct MainView: View {
 
     var body: some View {
         NavigationSplitView {
-            // Left sidebar - Categories & Feeds
-            SidebarPlaceholderView()
-                .frame(minWidth: 200, idealWidth: 250, maxWidth: 300)
+            // Left sidebar - Folders & Feeds
+            SidebarView()
         } content: {
             // Middle pane - Article List
             ArticleListPlaceholderView()
@@ -40,20 +39,6 @@ struct MainView: View {
 }
 
 // MARK: - Placeholder Views
-
-/// Placeholder for the sidebar view until fully implemented.
-struct SidebarPlaceholderView: View {
-    var body: some View {
-        VStack {
-            Image(systemName: "folder")
-                .font(.largeTitle)
-                .foregroundStyle(.secondary)
-            Text("Categories & Feeds")
-                .foregroundStyle(.secondary)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-    }
-}
 
 /// Placeholder for the article list view until fully implemented.
 struct ArticleListPlaceholderView: View {

--- a/RSSReader/Views/Sidebar/FeedRowView.swift
+++ b/RSSReader/Views/Sidebar/FeedRowView.swift
@@ -1,0 +1,41 @@
+//
+//  FeedRowView.swift
+//  RSSReader
+//
+//  Created on 2026-01-29.
+//
+
+import SwiftUI
+
+/// A single feed row showing an RSS icon, title, unread
+/// badge, and optional error overlay.
+struct FeedRowView: View {
+    @ObservedObject var feed: CDFeed
+
+    var body: some View {
+        Label {
+            Text(feed.title)
+                .lineLimit(1)
+        } icon: {
+            feedIcon
+        }
+        .badge(feed.unreadCount)
+        .help(feed.lastError ?? feed.feedURL)
+    }
+
+    // MARK: - Subviews
+
+    private var feedIcon: some View {
+        ZStack(alignment: .bottomTrailing) {
+            Image(systemName: "dot.radiowaves.up.forward")
+                .foregroundStyle(.secondary)
+
+            if feed.hasError {
+                Image(systemName: "exclamationmark.circle.fill")
+                    .font(.caption2)
+                    .foregroundStyle(.red)
+                    .offset(x: 4, y: 4)
+            }
+        }
+    }
+}

--- a/RSSReader/Views/Sidebar/FolderRowView.swift
+++ b/RSSReader/Views/Sidebar/FolderRowView.swift
@@ -1,0 +1,25 @@
+//
+//  FolderRowView.swift
+//  RSSReader
+//
+//  Created on 2026-01-29.
+//
+
+import SwiftUI
+
+/// A folder label showing a folder icon, name, and
+/// aggregate unread badge.
+struct FolderRowView: View {
+    @ObservedObject var folder: CDFolder
+
+    var body: some View {
+        Label {
+            Text(folder.name)
+                .lineLimit(1)
+        } icon: {
+            Image(systemName: "folder")
+                .foregroundStyle(.secondary)
+        }
+        .badge(folder.unreadCount)
+    }
+}

--- a/RSSReader/Views/Sidebar/SidebarView.swift
+++ b/RSSReader/Views/Sidebar/SidebarView.swift
@@ -1,0 +1,83 @@
+//
+//  SidebarView.swift
+//  RSSReader
+//
+//  Created on 2026-01-29.
+//
+
+import CoreData
+import SwiftUI
+
+/// Sidebar displaying folders (with expandable feeds) and
+/// an unfiled feeds section. Drives selection state via
+/// `SidebarViewModel`.
+struct SidebarView: View {
+    @StateObject private var viewModel = SidebarViewModel()
+
+    @FetchRequest(
+        sortDescriptors: [
+            SortDescriptor(\CDFolder.sortOrder),
+            SortDescriptor(\CDFolder.name)
+        ],
+        animation: .default
+    ) private var folders: FetchedResults<CDFolder>
+
+    @FetchRequest(
+        sortDescriptors: [
+            SortDescriptor(\CDFeed.title)
+        ],
+        predicate: NSPredicate(
+            format: "folder == nil"
+        ),
+        animation: .default
+    ) private var unfiledFeeds: FetchedResults<CDFeed>
+
+    var body: some View {
+        List(selection: $viewModel.selection) {
+            foldersSection
+            unfiledFeedsSection
+        }
+        .listStyle(.sidebar)
+        .frame(minWidth: 200)
+    }
+
+    // MARK: - Sections
+
+    @ViewBuilder
+    private var foldersSection: some View {
+        ForEach(folders, id: \.id) { folder in
+            DisclosureGroup(
+                isExpanded: viewModel.expandedBinding(
+                    for: folder.id
+                )
+            ) {
+                ForEach(
+                    folder.sortedFeeds,
+                    id: \.id
+                ) { feed in
+                    FeedRowView(feed: feed)
+                        .tag(
+                            SidebarSelection.feed(feed.id)
+                        )
+                }
+            } label: {
+                FolderRowView(folder: folder)
+            }
+            .tag(SidebarSelection.folder(folder.id))
+        }
+    }
+
+    @ViewBuilder
+    private var unfiledFeedsSection: some View {
+        if !unfiledFeeds.isEmpty {
+            Section("Unfiled") {
+                ForEach(unfiledFeeds, id: \.id) { feed in
+                    FeedRowView(feed: feed)
+                        .tag(
+                            SidebarSelection.feed(feed.id)
+                        )
+                }
+            }
+        }
+    }
+}

--- a/RSSReaderTests/UnitTests/Models/CDFeedTests.swift
+++ b/RSSReaderTests/UnitTests/Models/CDFeedTests.swift
@@ -209,6 +209,29 @@ struct CDFeedTests {
         #expect(feed.unreadCount == 0)
     }
 
+    @Test("hasError is true when lastError is set")
+    func hasErrorWhenErrorExists() {
+        let context = CoreDataTestHelper.makeContext()
+        let feed = CDFeed.create(
+            in: context,
+            title: "Broken",
+            feedURL: "https://example.com/feed"
+        )
+        feed.lastError = "Connection timeout"
+        #expect(feed.hasError)
+    }
+
+    @Test("hasError is false when lastError is nil")
+    func hasErrorWhenNoError() {
+        let context = CoreDataTestHelper.makeContext()
+        let feed = CDFeed.create(
+            in: context,
+            title: "Healthy",
+            feedURL: "https://example.com/feed"
+        )
+        #expect(!feed.hasError)
+    }
+
     @Test("Unread count is zero when all articles are read")
     func unreadCountAllRead() throws {
         let context = CoreDataTestHelper.makeContext()

--- a/RSSReaderTests/UnitTests/Models/CDFolderTests.swift
+++ b/RSSReaderTests/UnitTests/Models/CDFolderTests.swift
@@ -115,6 +115,29 @@ struct CDFolderTests {
         #expect(folder.unreadCount == 3)
     }
 
+    @Test("sortedFeeds returns feeds alphabetically by title")
+    func sortedFeedsOrder() throws {
+        let context = CoreDataTestHelper.makeContext()
+        let folder = CDFolder.create(in: context, name: "Tech")
+        makeFeed(context: context, title: "Zebra", folder: folder)
+        makeFeed(context: context, title: "Apple", folder: folder)
+        makeFeed(context: context, title: "Mango", folder: folder)
+        try context.save()
+
+        let sorted = folder.sortedFeeds
+        #expect(sorted.count == 3)
+        #expect(sorted[0].title == "Apple")
+        #expect(sorted[1].title == "Mango")
+        #expect(sorted[2].title == "Zebra")
+    }
+
+    @Test("sortedFeeds returns empty array when no feeds")
+    func sortedFeedsEmpty() {
+        let context = CoreDataTestHelper.makeContext()
+        let folder = CDFolder.create(in: context, name: "Empty")
+        #expect(folder.sortedFeeds.isEmpty)
+    }
+
     @Test("Unread count is zero when no feeds")
     func unreadCountNoFeeds() {
         let context = CoreDataTestHelper.makeContext()

--- a/RSSReaderTests/UnitTests/ViewModels/SidebarViewModelTests.swift
+++ b/RSSReaderTests/UnitTests/ViewModels/SidebarViewModelTests.swift
@@ -1,0 +1,220 @@
+//
+//  SidebarViewModelTests.swift
+//  RSSReaderTests
+//
+//  Created on 2026-01-29.
+//
+
+import Foundation
+import Testing
+@testable import RSSReader
+
+@Suite("SidebarViewModel Tests")
+struct SidebarViewModelTests {
+
+    // MARK: - Initial State
+
+    @Test("Selection is nil on init")
+    @MainActor
+    func initialSelectionIsNil() {
+        let vm = SidebarViewModel()
+        #expect(vm.selection == nil)
+    }
+
+    @Test("No folders are collapsed on init")
+    @MainActor
+    func initialExpansionState() {
+        let vm = SidebarViewModel()
+        #expect(vm.collapsedFolders.isEmpty)
+    }
+
+    // MARK: - Selection
+
+    @Test("Select folder sets selection to folder case")
+    @MainActor
+    func selectFolder() {
+        let vm = SidebarViewModel()
+        let id = UUID()
+        vm.selectFolder(id)
+        #expect(vm.selection == .folder(id))
+    }
+
+    @Test("Select feed sets selection to feed case")
+    @MainActor
+    func selectFeed() {
+        let vm = SidebarViewModel()
+        let id = UUID()
+        vm.selectFeed(id)
+        #expect(vm.selection == .feed(id))
+    }
+
+    @Test("selectedFolderId returns UUID when folder selected")
+    @MainActor
+    func selectedFolderIdWhenFolderSelected() {
+        let vm = SidebarViewModel()
+        let id = UUID()
+        vm.selectFolder(id)
+        #expect(vm.selectedFolderId == id)
+    }
+
+    @Test("selectedFolderId is nil when feed selected")
+    @MainActor
+    func selectedFolderIdWhenFeedSelected() {
+        let vm = SidebarViewModel()
+        vm.selectFeed(UUID())
+        #expect(vm.selectedFolderId == nil)
+    }
+
+    @Test("selectedFeedId returns UUID when feed selected")
+    @MainActor
+    func selectedFeedIdWhenFeedSelected() {
+        let vm = SidebarViewModel()
+        let id = UUID()
+        vm.selectFeed(id)
+        #expect(vm.selectedFeedId == id)
+    }
+
+    @Test("selectedFeedId is nil when folder selected")
+    @MainActor
+    func selectedFeedIdWhenFolderSelected() {
+        let vm = SidebarViewModel()
+        vm.selectFolder(UUID())
+        #expect(vm.selectedFeedId == nil)
+    }
+
+    @Test("clearSelection resets selection to nil")
+    @MainActor
+    func clearSelection() {
+        let vm = SidebarViewModel()
+        vm.selectFolder(UUID())
+        vm.clearSelection()
+        #expect(vm.selection == nil)
+    }
+
+    @Test("Selecting feed replaces previous folder selection")
+    @MainActor
+    func selectionReplacesPrevious() {
+        let vm = SidebarViewModel()
+        let folderId = UUID()
+        let feedId = UUID()
+        vm.selectFolder(folderId)
+        vm.selectFeed(feedId)
+        #expect(vm.selectedFolderId == nil)
+        #expect(vm.selectedFeedId == feedId)
+    }
+
+    // MARK: - Folder Expansion
+
+    @Test("Folders default to expanded")
+    @MainActor
+    func foldersDefaultToExpanded() {
+        let vm = SidebarViewModel()
+        let id = UUID()
+        #expect(vm.isFolderExpanded(id))
+    }
+
+    @Test("setFolderExpanded false collapses folder")
+    @MainActor
+    func setFolderCollapsed() {
+        let vm = SidebarViewModel()
+        let id = UUID()
+        vm.setFolderExpanded(id, isExpanded: false)
+        #expect(!vm.isFolderExpanded(id))
+    }
+
+    @Test("setFolderExpanded true re-expands folder")
+    @MainActor
+    func setFolderReExpanded() {
+        let vm = SidebarViewModel()
+        let id = UUID()
+        vm.setFolderExpanded(id, isExpanded: false)
+        vm.setFolderExpanded(id, isExpanded: true)
+        #expect(vm.isFolderExpanded(id))
+    }
+
+    @Test("toggleFolderExpansion collapses expanded folder")
+    @MainActor
+    func toggleCollapse() {
+        let vm = SidebarViewModel()
+        let id = UUID()
+        vm.toggleFolderExpansion(id)
+        #expect(!vm.isFolderExpanded(id))
+    }
+
+    @Test("toggleFolderExpansion expands collapsed folder")
+    @MainActor
+    func toggleExpand() {
+        let vm = SidebarViewModel()
+        let id = UUID()
+        vm.toggleFolderExpansion(id)
+        vm.toggleFolderExpansion(id)
+        #expect(vm.isFolderExpanded(id))
+    }
+
+    @Test("Collapsing one folder does not affect others")
+    @MainActor
+    func independentFolderExpansion() {
+        let vm = SidebarViewModel()
+        let id1 = UUID()
+        let id2 = UUID()
+        vm.setFolderExpanded(id1, isExpanded: false)
+        #expect(!vm.isFolderExpanded(id1))
+        #expect(vm.isFolderExpanded(id2))
+    }
+
+    // MARK: - Expanded Binding
+
+    @Test("expandedBinding getter returns correct state")
+    @MainActor
+    func expandedBindingGetter() {
+        let vm = SidebarViewModel()
+        let id = UUID()
+        let binding = vm.expandedBinding(for: id)
+        #expect(binding.wrappedValue == true)
+
+        vm.setFolderExpanded(id, isExpanded: false)
+        #expect(binding.wrappedValue == false)
+    }
+
+    @Test("expandedBinding setter updates state")
+    @MainActor
+    func expandedBindingSetter() {
+        let vm = SidebarViewModel()
+        let id = UUID()
+        let binding = vm.expandedBinding(for: id)
+        binding.wrappedValue = false
+        #expect(!vm.isFolderExpanded(id))
+
+        binding.wrappedValue = true
+        #expect(vm.isFolderExpanded(id))
+    }
+
+    // MARK: - SidebarSelection Equality
+
+    @Test("SidebarSelection folder equality")
+    func folderEquality() {
+        let id = UUID()
+        #expect(
+            SidebarSelection.folder(id)
+                == SidebarSelection.folder(id)
+        )
+    }
+
+    @Test("SidebarSelection feed equality")
+    func feedEquality() {
+        let id = UUID()
+        #expect(
+            SidebarSelection.feed(id)
+                == SidebarSelection.feed(id)
+        )
+    }
+
+    @Test("SidebarSelection folder != feed with same UUID")
+    func folderNotEqualToFeed() {
+        let id = UUID()
+        #expect(
+            SidebarSelection.folder(id)
+                != SidebarSelection.feed(id)
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Implements the sidebar with folders (expandable DisclosureGroups) and an unfiled feeds section
- Adds `SidebarViewModel` managing selection state (folder/feed) and folder expansion with `Binding` support
- Creates `SidebarView`, `FolderRowView`, and `FeedRowView` with SF Symbol icons, unread count badges, and error icon overlays
- Replaces `SidebarPlaceholderView` in `MainView` with the real `SidebarView`
- Adds `CDFolder.sortedFeeds` and `CDFeed.hasError` computed properties
- 24 new unit tests (110 total, all passing)

## Acceptance Criteria
- [x] SidebarView created with SwiftUI List
- [x] Folders displayed with disclosure groups (expandable)
- [x] Feeds displayed within their parent folders
- [x] Unfiled feeds section for feeds without a folder
- [x] Unread count badges on feeds
- [x] Unread count badges on folders (sum of feed unread counts)
- [x] Folder selection state handling
- [x] Feed selection state handling
- [x] SF Symbols for icons (folder, rss)
- [x] Error icon overlay for feeds with fetch errors
- [x] Proper macOS styling and spacing
- [x] Minimum width: 200pt
- [x] Smooth animations for expand/collapse

## Test plan
- [x] `SidebarViewModelTests` — 20 tests covering selection, expansion, bindings, and equality
- [x] `CDFolderTests` — 2 new tests for `sortedFeeds` (ordering + empty)
- [x] `CDFeedTests` — 2 new tests for `hasError` (true/false)
- [x] All 110 tests pass via `swift test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)