### PR TITLE
Closes #13: Article Detail View - Reading Pane

### DIFF
--- a/RSSReader/ViewModels/ArticleDetailViewModel.swift
+++ b/RSSReader/ViewModels/ArticleDetailViewModel.swift
@@ -1,0 +1,67 @@
+//
+//  ArticleDetailViewModel.swift
+//  RSSReader
+//
+//  Created on 2026-01-30.
+//
+
+import AppKit
+import CoreData
+import Foundation
+
+/// ViewModel managing article detail display and actions.
+///
+/// Provides mark-as-read logic, HTML-stripped plain text
+/// content, date formatting, and Safari integration.
+@MainActor
+final class ArticleDetailViewModel: ObservableObject {
+
+    // MARK: - Date Formatting
+
+    private static let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .long
+        formatter.timeStyle = .short
+        return formatter
+    }()
+
+    /// Formats a date for display in the article header.
+    func formattedDate(_ date: Date) -> String {
+        Self.dateFormatter.string(from: date)
+    }
+
+    // MARK: - Content
+
+    /// Returns the article body as plain text, stripping
+    /// HTML tags. Prefers `content` over `summary`.
+    func plainTextContent(
+        for article: CDArticle
+    ) -> String {
+        let raw = article.content
+            ?? article.summary
+            ?? ""
+        return raw.stripHTML()
+    }
+
+    // MARK: - Actions
+
+    /// Marks the article as read in Core Data if it is
+    /// currently unread. Saves the context immediately so
+    /// unread counts update reactively.
+    func markAsRead(
+        _ article: CDArticle,
+        in context: NSManagedObjectContext
+    ) {
+        guard !article.isRead else { return }
+        article.isRead = true
+        try? context.save()
+    }
+
+    /// Opens the article link in the default browser.
+    func openInSafari(urlString: String) {
+        guard let url = URL(string: urlString) else {
+            return
+        }
+        NSWorkspace.shared.open(url)
+    }
+}

--- a/RSSReader/Views/ArticleDetail/ArticleDetailView.swift
+++ b/RSSReader/Views/ArticleDetail/ArticleDetailView.swift
@@ -1,0 +1,194 @@
+//
+//  ArticleDetailView.swift
+//  RSSReader
+//
+//  Created on 2026-01-30.
+//
+
+import CoreData
+import SwiftUI
+
+/// Reading pane displaying the selected article's title,
+/// metadata, plain-text content, and a Safari action button.
+///
+/// Automatically marks the article as read when displayed.
+struct ArticleDetailView: View {
+    let articleId: String?
+
+    @StateObject private var viewModel =
+        ArticleDetailViewModel()
+
+    @Environment(\.managedObjectContext)
+    private var context
+
+    @FetchRequest private var articles:
+        FetchedResults<CDArticle>
+
+    // MARK: - Init
+
+    init(articleId: String?) {
+        self.articleId = articleId
+
+        let predicate: NSPredicate
+        if let articleId {
+            predicate = NSPredicate(
+                format: "id == %@", articleId
+            )
+        } else {
+            predicate = NSPredicate(value: false)
+        }
+
+        _articles = FetchRequest(
+            sortDescriptors: [],
+            predicate: predicate
+        )
+    }
+
+    private var article: CDArticle? {
+        articles.first
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        Group {
+            if let article {
+                articleContent(article)
+            } else {
+                emptyState
+            }
+        }
+        .frame(
+            minWidth: 500,
+            maxWidth: .infinity,
+            maxHeight: .infinity
+        )
+        .onChange(of: articleId) { _, newId in
+            if let newId, let art = articles.first,
+               art.id == newId {
+                viewModel.markAsRead(art, in: context)
+            }
+        }
+    }
+
+    // MARK: - Article Content
+
+    private func articleContent(
+        _ article: CDArticle
+    ) -> some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                metadataHeader(article)
+                Divider()
+                bodyText(article)
+                Spacer(minLength: 24)
+                actionsBar(article)
+            }
+            .padding(24)
+        }
+        .onAppear {
+            viewModel.markAsRead(article, in: context)
+        }
+    }
+
+    // MARK: - Metadata Header
+
+    private func metadataHeader(
+        _ article: CDArticle
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(article.title)
+                .font(.title)
+                .fontWeight(.bold)
+                .textSelection(.enabled)
+
+            HStack(spacing: 12) {
+                if let author = article.author,
+                   !author.isEmpty {
+                    Label(author, systemImage: "person")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+
+                Label(
+                    viewModel.formattedDate(
+                        article.published
+                    ),
+                    systemImage: "calendar"
+                )
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+
+                if let feedTitle = article.feed?.title {
+                    Label(
+                        feedTitle,
+                        systemImage:
+                            "dot.radiowaves.up.forward"
+                    )
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+
+    // MARK: - Body Text
+
+    private func bodyText(
+        _ article: CDArticle
+    ) -> some View {
+        let text = viewModel.plainTextContent(
+            for: article
+        )
+
+        return Group {
+            if text.isEmpty {
+                Text("No content available.")
+                    .foregroundStyle(.tertiary)
+                    .italic()
+            } else {
+                Text(text)
+                    .font(.body)
+                    .lineSpacing(6)
+                    .textSelection(.enabled)
+            }
+        }
+    }
+
+    // MARK: - Actions Bar
+
+    private func actionsBar(
+        _ article: CDArticle
+    ) -> some View {
+        HStack {
+            Button {
+                viewModel.openInSafari(
+                    urlString: article.link
+                )
+            } label: {
+                Label(
+                    "Open in Safari",
+                    systemImage: "safari"
+                )
+            }
+            .buttonStyle(.borderedProminent)
+            Spacer()
+        }
+    }
+
+    // MARK: - Empty State
+
+    private var emptyState: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "doc.text")
+                .font(.largeTitle)
+                .foregroundStyle(.secondary)
+            Text("Select an article to read")
+                .foregroundStyle(.secondary)
+        }
+        .frame(
+            maxWidth: .infinity,
+            maxHeight: .infinity
+        )
+    }
+}

--- a/RSSReader/Views/ArticleList/ArticleListView.swift
+++ b/RSSReader/Views/ArticleList/ArticleListView.swift
@@ -16,8 +16,7 @@ import SwiftUI
 struct ArticleListView: View {
     let sidebarSelection: SidebarSelection?
 
-    @StateObject private var viewModel =
-        ArticleListViewModel()
+    @ObservedObject var viewModel: ArticleListViewModel
 
     @FetchRequest(
         sortDescriptors: [

--- a/RSSReader/Views/MainView.swift
+++ b/RSSReader/Views/MainView.swift
@@ -12,6 +12,8 @@ struct MainView: View {
     @EnvironmentObject var appState: AppState
     @StateObject private var sidebarViewModel =
         SidebarViewModel()
+    @StateObject private var listViewModel =
+        ArticleListViewModel()
 
     var body: some View {
         NavigationSplitView {
@@ -21,12 +23,15 @@ struct MainView: View {
             // Middle pane - Article List
             ArticleListView(
                 sidebarSelection:
-                    sidebarViewModel.selection
+                    sidebarViewModel.selection,
+                viewModel: listViewModel
             )
         } detail: {
             // Right pane - Article Content
-            ArticleDetailPlaceholderView()
-                .frame(minWidth: 500)
+            ArticleDetailView(
+                articleId:
+                    listViewModel.selectedArticleId
+            )
         }
         .navigationSplitViewStyle(.balanced)
         .toolbar {
@@ -48,21 +53,5 @@ struct MainView: View {
                 )
             }
         }
-    }
-}
-
-// MARK: - Placeholder Views
-
-/// Placeholder for the article detail view.
-struct ArticleDetailPlaceholderView: View {
-    var body: some View {
-        VStack {
-            Image(systemName: "doc.text")
-                .font(.largeTitle)
-                .foregroundStyle(.secondary)
-            Text("Select an article to read")
-                .foregroundStyle(.secondary)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 }

--- a/RSSReaderTests/UnitTests/ViewModels/ArticleDetailViewModelTests.swift
+++ b/RSSReaderTests/UnitTests/ViewModels/ArticleDetailViewModelTests.swift
@@ -1,0 +1,154 @@
+//
+//  ArticleDetailViewModelTests.swift
+//  RSSReaderTests
+//
+//  Created on 2026-01-30.
+//
+
+import CoreData
+import Foundation
+import Testing
+@testable import RSSReader
+
+@Suite("ArticleDetailViewModel Tests")
+struct ArticleDetailViewModelTests {
+
+    // MARK: - Mark as Read
+
+    @Test("markAsRead sets isRead to true")
+    @MainActor
+    func markAsRead() throws {
+        let context = CoreDataTestHelper.makeContext()
+        let article = CDArticle.create(
+            in: context,
+            id: "a1",
+            title: "Test",
+            link: "https://example.com",
+            published: Date()
+        )
+        try context.save()
+        #expect(!article.isRead)
+
+        let vm = ArticleDetailViewModel()
+        vm.markAsRead(article, in: context)
+        #expect(article.isRead)
+    }
+
+    @Test("markAsRead does not save if already read")
+    @MainActor
+    func markAsReadAlreadyRead() throws {
+        let context = CoreDataTestHelper.makeContext()
+        let article = CDArticle.create(
+            in: context,
+            id: "a1",
+            title: "Test",
+            link: "https://example.com",
+            published: Date()
+        )
+        article.isRead = true
+        try context.save()
+
+        let vm = ArticleDetailViewModel()
+        vm.markAsRead(article, in: context)
+        // Should still be read, no error thrown
+        #expect(article.isRead)
+    }
+
+    // MARK: - Plain Text Content
+
+    @Test("plainTextContent prefers content over summary")
+    @MainActor
+    func plainTextPrefersContent() {
+        let context = CoreDataTestHelper.makeContext()
+        let article = CDArticle.create(
+            in: context,
+            id: "a1",
+            title: "Test",
+            link: "https://example.com",
+            published: Date()
+        )
+        article.content = "Full content here"
+        article.summary = "Short summary"
+
+        let vm = ArticleDetailViewModel()
+        let text = vm.plainTextContent(for: article)
+        #expect(text == "Full content here")
+    }
+
+    @Test("plainTextContent falls back to summary")
+    @MainActor
+    func plainTextFallsBackToSummary() {
+        let context = CoreDataTestHelper.makeContext()
+        let article = CDArticle.create(
+            in: context,
+            id: "a1",
+            title: "Test",
+            link: "https://example.com",
+            published: Date()
+        )
+        article.summary = "Just the summary"
+
+        let vm = ArticleDetailViewModel()
+        let text = vm.plainTextContent(for: article)
+        #expect(text == "Just the summary")
+    }
+
+    @Test("plainTextContent returns empty when no content")
+    @MainActor
+    func plainTextEmpty() {
+        let context = CoreDataTestHelper.makeContext()
+        let article = CDArticle.create(
+            in: context,
+            id: "a1",
+            title: "Test",
+            link: "https://example.com",
+            published: Date()
+        )
+
+        let vm = ArticleDetailViewModel()
+        let text = vm.plainTextContent(for: article)
+        #expect(text.isEmpty)
+    }
+
+    @Test("plainTextContent strips HTML tags")
+    @MainActor
+    func plainTextStripsHTML() {
+        let context = CoreDataTestHelper.makeContext()
+        let article = CDArticle.create(
+            in: context,
+            id: "a1",
+            title: "Test",
+            link: "https://example.com",
+            published: Date()
+        )
+        article.content = "<p>Hello <b>world</b></p>"
+
+        let vm = ArticleDetailViewModel()
+        let text = vm.plainTextContent(for: article)
+        #expect(!text.contains("<"))
+        #expect(text.contains("Hello"))
+        #expect(text.contains("world"))
+    }
+
+    // MARK: - Date Formatting
+
+    @Test("formattedDate returns non-empty string")
+    @MainActor
+    func formattedDateNotEmpty() {
+        let vm = ArticleDetailViewModel()
+        let result = vm.formattedDate(Date())
+        #expect(!result.isEmpty)
+    }
+
+    @Test("formattedDate is deterministic for same date")
+    @MainActor
+    func formattedDateDeterministic() {
+        let vm = ArticleDetailViewModel()
+        let date = Date(
+            timeIntervalSinceReferenceDate: 0
+        )
+        let first = vm.formattedDate(date)
+        let second = vm.formattedDate(date)
+        #expect(first == second)
+    }
+}


### PR DESCRIPTION
## Summary
- Implements the reading pane with article title, metadata header (author, date, feed name), scrollable HTML-stripped plain text content, and "Open in Safari" button
- Adds `ArticleDetailViewModel` with `markAsRead` (Core Data save), `plainTextContent` (HTML stripping via `String.stripHTML()`, prefers content over summary), date formatting, and Safari integration
- Adds `ArticleDetailView` using `@FetchRequest` by article ID, with empty state when no article is selected
- Automatically marks articles as read when displayed
- Lifts `ArticleListViewModel` to `MainView` so `selectedArticleId` drives the detail pane

## Acceptance Criteria
- [x] ArticleDetailView created with SwiftUI
- [x] Article title displayed prominently
- [x] Article metadata header (author, date, source feed name)
- [x] Plain text content display (HTML stripped)
- [x] Open in Safari button/link
- [x] Scrollable content area
- [x] Empty state when no article selected
- [x] Proper typography and readability
- [x] Minimum width: 500pt
- [x] Automatic mark as read when displayed (updates Core Data)

## Test plan
- [x] `ArticleDetailViewModelTests` — 8 tests: markAsRead (unread → read, already read), plainTextContent (content preferred, summary fallback, empty, HTML stripping), formattedDate (non-empty, deterministic)
- [x] All 140 tests pass via `swift test`

> **Note:** Base branch is `feature/issue-12-article-list-view` (#35) since #13 depends on the article list selection state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)