### PR TITLE
Closes #51: Fix folder selection in sidebar

### DIFF
--- a/RSSReader/Views/Sidebar/SidebarView.swift
+++ b/RSSReader/Views/Sidebar/SidebarView.swift
@@ -125,6 +125,11 @@ struct SidebarView: View {
                 }
             } label: {
                 FolderRowView(folder: folder)
+                    .onTapGesture {
+                        viewModel.selection = .folder(
+                            folder.id
+                        )
+                    }
             }
             .tag(SidebarSelection.folder(folder.id))
             .contextMenu {


### PR DESCRIPTION
This PR fixes a bug where clicking on a folder in the sidebar would not filter the article list. 

**Manual Testing Steps:**
1.  Create a new folder.
2.  Add a feed to the folder.
3.  Click on the folder in the sidebar.
4.  Verify that the article list updates to show only the articles from the feeds within that folder.