### PR TITLE
Closes #52: Fix feed selection not filtering article list

### DIFF
--- a/RSSReader/Views/Sidebar/SidebarView.swift
+++ b/RSSReader/Views/Sidebar/SidebarView.swift
@@ -119,6 +119,11 @@ struct SidebarView: View {
                                 feed.id
                             )
                         )
+                        .onTapGesture {
+                            viewModel.selection = .feed(
+                                feed.id
+                            )
+                        }
                         .contextMenu {
                             feedContextMenu(feed: feed)
                         }
@@ -151,6 +156,11 @@ struct SidebarView: View {
                                 feed.id
                             )
                         )
+                        .onTapGesture {
+                            viewModel.selection = .feed(
+                                feed.id
+                            )
+                        }
                         .contextMenu {
                             feedContextMenu(feed: feed)
                         }


### PR DESCRIPTION
## Summary
- Fix feed selection inside folders not properly filtering the article list
- Add explicit .onTapGesture handlers to FeedRowView (matching the folder fix from PR #58)
- Applied to both feeds inside folders and unfiled feeds for consistency

## Root Cause
Feeds inside DisclosureGroups were relying solely on SwiftUI List's .tag() mechanism for selection. However, when nested inside a DisclosureGroup, tap gestures can be intercepted, preventing proper selection propagation to the List's selection binding.

## Fix
Added explicit .onTapGesture handlers that directly set viewModel.selection = .feed(feed.id), bypassing the DisclosureGroup's gesture handling.

## Test plan
- [ ] Open app with multiple feeds in folders
- [ ] Click on a feed inside a folder
- [ ] Verify article list shows only articles from that specific feed
- [ ] Click on a different feed
- [ ] Verify article list updates to show only articles from the newly selected feed
- [ ] Test unfiled feeds selection as well

Generated with Claude Code