### PR TITLE
Closes #49: Fix File > New Folder menu item not working

### DIFF
--- a/RSSReader/Views/ContentView.swift
+++ b/RSSReader/Views/ContentView.swift
@@ -99,6 +99,14 @@ struct ContentView: View {
         ) { _ in
             showingAddFeed = true
         }
+        .onReceive(
+            NotificationCenter.default.publisher(
+                for: .newFolder
+            )
+        ) { _ in
+            sidebarViewModel.folderNameInput = ""
+            sidebarViewModel.showNewFolderAlert = true
+        }
         .sheet(isPresented: $showingAddFeed) {
             AddFeedSheet()
         }


### PR DESCRIPTION
## Summary
- Fix File > New Folder menu item (Cmd+Shift+N) which did nothing when clicked
- Add missing .onReceive() handler for .newFolder notification in ContentView

## Root Cause
The menu item in KeyboardCommands.swift correctly posted a .newFolder notification, but ContentView.swift had no handler for it. The folder creation dialog (showNewFolderAlert) existed in SidebarView but was only accessible via right-click context menus.

## Fix
Added .onReceive() handler that:
1. Clears the folder name input field
2. Triggers the new folder alert dialog

## Test plan
- [ ] Open the app
- [ ] Go to File > New Folder (or press Cmd+Shift+N)
- [ ] Verify the New Folder dialog appears
- [ ] Enter a folder name and click Create
- [ ] Verify the new folder appears in the sidebar

Generated with Claude Code