### PR TITLE
Closes #48: Fix keyboard navigation shortcuts not working

### DIFF
--- a/RSSReader/Views/ArticleList/ArticleListView.swift
+++ b/RSSReader/Views/ArticleList/ArticleListView.swift
@@ -73,6 +73,38 @@ struct ArticleListView: View {
                 in: context
             )
         }
+        .onReceive(
+            NotificationCenter.default.publisher(
+                for: .nextArticle
+            )
+        ) { _ in
+            let ids = articles.map(\.id)
+            viewModel.selectNext(from: ids)
+        }
+        .onReceive(
+            NotificationCenter.default.publisher(
+                for: .previousArticle
+            )
+        ) { _ in
+            let ids = articles.map(\.id)
+            viewModel.selectPrevious(from: ids)
+        }
+        .onReceive(
+            NotificationCenter.default.publisher(
+                for: .nextUnread
+            )
+        ) { _ in
+            let ids = articles.map(\.id)
+            let unreadIds = Set(
+                articles
+                    .filter { !$0.isRead }
+                    .map(\.id)
+            )
+            viewModel.selectNextUnread(
+                from: ids,
+                unreadIds: unreadIds
+            )
+        }
     }
 
     // MARK: - Subviews


### PR DESCRIPTION
## Summary
- Fix keyboard navigation shortcuts (n, up/down arrows) which did nothing when pressed
- Add missing .onReceive() handlers in ArticleListView for navigation notifications

## Root Cause
The Navigation menu in KeyboardCommands.swift correctly posted notifications (.nextUnread, .previousArticle, .nextArticle), but ArticleListView had no handlers for them. The ArticleListViewModel already had the navigation methods implemented, they just weren't being called.

## Fix
Added .onReceive() handlers in ArticleListView for:
- .nextArticle (↓) → calls viewModel.selectNext()
- .previousArticle (↑) → calls viewModel.selectPrevious()  
- .nextUnread (n) → calls viewModel.selectNextUnread()

Note: .openInSafari (Enter/Space) was already handled by ArticleDetailView.

## Test plan
- [ ] Open app with articles loaded
- [ ] Select an article
- [ ] Press Down arrow - should select next article
- [ ] Press Up arrow - should select previous article
- [ ] Press 'n' - should jump to next unread article
- [ ] Press Enter or Space - should open article in Safari
- [ ] Verify Navigation menu shows all shortcuts

Generated with Claude Code