### PR TITLE
Closes #55: Set app version to v0.0.1-alpha

### DIFF
--- a/RSSReader.xcodeproj/project.pbxproj
+++ b/RSSReader.xcodeproj/project.pbxproj
@@ -900,7 +900,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = "0.0.1-alpha";
 				PRODUCT_BUNDLE_IDENTIFIER = com.rssreader.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -929,7 +929,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = "0.0.1-alpha";
 				PRODUCT_BUNDLE_IDENTIFIER = com.rssreader.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;


### PR DESCRIPTION
## Summary
- Updated MARKETING_VERSION from `1.0` to `0.0.1-alpha` in Xcode project settings
- Applied to both Debug and Release configurations for the main app target

## Test plan
- [ ] Build the app
- [ ] Go to RSSReader > About RSSReader
- [ ] Verify version displays as "0.0.1-alpha"

🤖 Generated with [Claude Code](https://claude.ai/claude-code)