### PR TITLE
Fix SwiftLint violations blocking CI

### DIFF
--- a/RSSReader/Views/ArticleDetail/ArticleDetailView.swift
+++ b/RSSReader/Views/ArticleDetail/ArticleDetailView.swift
@@ -68,7 +68,7 @@ struct ArticleDetailView: View {
             maxHeight: .infinity
         )
         .ignoresSafeArea(.all, edges: .top)
-        .onChange(of: articleId) { oldId, newId in
+        .onChange(of: articleId) { oldId, _ in
             if let oldId {
                 let fetchRequest: NSFetchRequest<CDArticle> = CDArticle.fetchRequest()
                 fetchRequest.predicate = NSPredicate(format: "id == %@", oldId as CVarArg)

--- a/RSSReader/Views/Sidebar/SidebarView.swift
+++ b/RSSReader/Views/Sidebar/SidebarView.swift
@@ -258,7 +258,7 @@ struct SidebarView: View {
 
     private func handleDrop(providers: [NSItemProvider], toFolderId folderId: UUID?) -> Bool {
         guard let provider = providers.first else { return false }
-        provider.loadObject(ofClass: NSString.self) { (string, error) in
+        provider.loadObject(ofClass: NSString.self) { string, error in
             if let error = error {
                 print("Error loading dragged object: \(error.localizedDescription)")
                 return


### PR DESCRIPTION
## Summary
- Fixed unused closure parameter in ArticleDetailView.swift (replaced `newId` with `_`)
- Fixed unneeded parentheses in closure argument in SidebarView.swift

## Test plan
- [x] Run `swiftlint lint --strict` locally - 0 violations
- [ ] CI lint check passes

These pre-existing violations were causing all PR lint checks to fail in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)