### PR TITLE
Fix sidebar selection not updating article list

### DIFF
--- a/RSSReader/Views/Sidebar/SidebarView.swift
+++ b/RSSReader/Views/Sidebar/SidebarView.swift
@@ -114,9 +114,6 @@ struct SidebarView: View {
     private var allArticlesRow: some View {
         AllArticlesRowView()
             .tag(SidebarSelection.all)
-            .onTapGesture {
-                viewModel.selection = .all
-            }
             .onDrop(of: [UTType.feedDrag], isTargeted: nil) { providers in
                 handleDrop(providers: providers, toFolderId: nil)
             }
@@ -140,22 +137,12 @@ struct SidebarView: View {
                                 feed.id
                             )
                         )
-                        .onTapGesture {
-                            viewModel.selection = .feed(
-                                feed.id
-                            )
-                        }
                         .contextMenu {
                             feedContextMenu(feed: feed)
                         }
                 }
             } label: {
                 FolderRowView(folder: folder)
-                    .onTapGesture {
-                        viewModel.selection = .folder(
-                            folder.id
-                        )
-                    }
                     .contextMenu {
                         folderContextMenu(folder: folder)
                     }
@@ -238,11 +225,6 @@ struct SidebarView: View {
                                 feed.id
                             )
                         )
-                        .onTapGesture {
-                            viewModel.selection = .feed(
-                                feed.id
-                            )
-                        }
                         .contextMenu {
                             feedContextMenu(feed: feed)
                         }


### PR DESCRIPTION
## Summary
Fixed bug where selecting a feed or folder in the sidebar did not update the article list to show only articles from that selection.

## Root Cause
Redundant onTapGesture handlers on sidebar items were interfering with SwiftUI's native List(selection:) mechanism. When using List(selection: $binding) with .tag() modifiers, the List handles selection automatically - the manual tap gesture handlers were intercepting taps before the List could process them.

## Fix
Removed all onTapGesture handlers from:
- All Articles row
- Folder labels  
- Feed rows (inside folders)
- Unfiled feed rows

The .tag() modifiers remain in place, allowing the List to handle selection correctly.

## Test plan
- [x] Build succeeds
- [x] SwiftLint passes (0 violations)
- [ ] Click on All Articles - article list shows all articles
- [ ] Click on a folder - article list shows only articles from feeds in that folder
- [ ] Click on a feed - article list shows only articles from that feed
- [ ] Click on unfiled feed - article list filters correctly

🤖 Generated with Claude Code