### PR TITLE
Closes #85: Fix periodic feed refresh not using saved settings

### DIFF
--- a/RSSReader/App/KeyboardCommands.swift
+++ b/RSSReader/App/KeyboardCommands.swift
@@ -139,4 +139,7 @@ extension Notification.Name {
     static let newFolder = Notification.Name(
         "newFolder"
     )
+    static let refreshIntervalChanged = Notification.Name(
+        "refreshIntervalChanged"
+    )
 }

--- a/RSSReader/Services/RefreshService.swift
+++ b/RSSReader/Services/RefreshService.swift
@@ -68,6 +68,18 @@ final class RefreshService: ObservableObject {
                 }
             }
             .store(in: &cancellables)
+
+        NotificationCenter.default
+            .publisher(for: .refreshIntervalChanged)
+            .sink { [weak self] notification in
+                guard let self else { return }
+                let newInterval = notification.userInfo?["interval"]
+                    as? TimeInterval ?? 600
+                Task { @MainActor in
+                    self.startAutoRefresh(interval: newInterval)
+                }
+            }
+            .store(in: &cancellables)
     }
 
     // MARK: - Manual Refresh

--- a/RSSReader/Views/ContentView.swift
+++ b/RSSReader/Views/ContentView.swift
@@ -73,7 +73,7 @@ struct ContentView: View {
             showingImportOPML = true
         }
         .onAppear {
-            refreshService.startAutoRefresh()
+            startAutoRefreshWithSavedInterval()
             setupKeyMonitor()
         }
         .onDisappear {
@@ -103,6 +103,19 @@ struct ContentView: View {
         ) { _ in
             refreshService.resumeAutoRefresh()
         }
+    }
+
+    // MARK: - Auto Refresh
+
+    /// Starts auto-refresh using the interval saved in settings.
+    private func startAutoRefreshWithSavedInterval() {
+        let interval: TimeInterval
+        if let settings = try? CDAppSettings.current(in: context) {
+            interval = TimeInterval(settings.refreshInterval)
+        } else {
+            interval = TimeInterval(CDAppSettings.defaultRefreshInterval)
+        }
+        refreshService.startAutoRefresh(interval: interval)
     }
 
     // MARK: - Keyboard Shortcuts

--- a/RSSReader/Views/Settings/SettingsView.swift
+++ b/RSSReader/Views/Settings/SettingsView.swift
@@ -96,6 +96,12 @@ struct SettingsView: View {
                 set: { newValue in
                     settings?.refreshInterval = newValue
                     saveSettings()
+                    // Notify RefreshService to restart with new interval
+                    NotificationCenter.default.post(
+                        name: .refreshIntervalChanged,
+                        object: nil,
+                        userInfo: ["interval": TimeInterval(newValue)]
+                    )
                 }
             )) {
                 ForEach(refreshIntervals, id: \.1) { option in

--- a/RSSReaderTests/UnitTests/Services/RefreshServiceTests.swift
+++ b/RSSReaderTests/UnitTests/Services/RefreshServiceTests.swift
@@ -523,6 +523,37 @@ struct RefreshServiceTests {
         // Both should succeed (no backoff)
         #expect(requestCount == 2)
     }
+
+    // MARK: - Refresh Interval Change Notification
+
+    @Test("RefreshService responds to refreshIntervalChanged notification")
+    @MainActor
+    func refreshIntervalChangedNotification() async {
+        let persistence = PersistenceController.inMemory()
+        let service = RefreshService(
+            persistence: persistence,
+            urlSession: Self.makeMockSession()
+        )
+
+        // Start with default interval
+        service.startAutoRefresh(interval: 600)
+
+        // Post notification with new interval
+        NotificationCenter.default.post(
+            name: .refreshIntervalChanged,
+            object: nil,
+            userInfo: ["interval": TimeInterval(1800)]
+        )
+
+        // Give time for notification to be processed
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        // Service should have restarted (no crash = success)
+        // Note: We can't directly verify the interval changed
+        // since it's internal, but the notification handler
+        // executes without error
+        service.stopAutoRefresh()
+    }
 }
 // swiftlint:enable type_body_length
 // swiftlint:enable file_length


### PR DESCRIPTION
## Summary
- Fixed periodic feed refresh not working with user-configured interval
- App was always using default 600s interval, ignoring saved settings
- Added notification mechanism to sync RefreshService with settings changes

## Changes
- Added `refreshIntervalChanged` notification
- `SettingsView` posts notification when refresh interval is changed
- `RefreshService` listens and restarts timer with new interval
- `ContentView` reads saved interval from Core Data on app launch

## Test plan
- [ ] Open Settings (Cmd+,) and change refresh interval to 5 minutes
- [ ] Verify auto-refresh triggers after 5 minutes (or test with shorter interval)
- [ ] Restart app and verify it uses the saved interval
- [ ] Run unit tests: `xcodebuild test -scheme RSSReader -only-testing:RSSReaderTests/UnitTests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)