### PR TITLE
Closes #86: Fix crash when removing duplicate feed

### DIFF
--- a/RSSReader/ViewModels/SidebarViewModel.swift
+++ b/RSSReader/ViewModels/SidebarViewModel.swift
@@ -204,6 +204,27 @@ final class SidebarViewModel: ObservableObject {
         try? context.save()
     }
 
+    /// Deletes a feed and clears selection if the feed
+    /// was currently selected. This prevents crashes from
+    /// SwiftUI trying to access deleted objects.
+    func deleteFeed(
+        id feedId: UUID,
+        in context: NSManagedObjectContext
+    ) {
+        // Clear selection first if this feed is selected
+        if case .feed(let selectedId) = selection,
+           selectedId == feedId {
+            selection = nil
+        }
+
+        guard let feed = fetchFeed(
+            id: feedId, in: context
+        ) else { return }
+
+        context.delete(feed)
+        try? context.save()
+    }
+
     /// Reorders a folder by moving it before or after
     /// another folder.
     func reorderFolder(

--- a/RSSReader/Views/Sidebar/SidebarFoldersView.swift
+++ b/RSSReader/Views/Sidebar/SidebarFoldersView.swift
@@ -183,19 +183,15 @@ struct SidebarFoldersView: View {
         }
         Divider()
         Button(role: .destructive) {
-            deleteFeed(feed)
+            viewModel.deleteFeed(
+                id: feed.id,
+                in: context
+            )
         } label: {
             Label(
                 "Remove Feed",
                 systemImage: "trash"
             )
         }
-    }
-
-    // MARK: - Actions
-
-    private func deleteFeed(_ feed: CDFeed) {
-        context.delete(feed)
-        try? context.save()
     }
 }

--- a/RSSReader/Views/Sidebar/SidebarUnfiledFeedsView.swift
+++ b/RSSReader/Views/Sidebar/SidebarUnfiledFeedsView.swift
@@ -99,19 +99,15 @@ struct SidebarUnfiledFeedsView: View {
         }
         Divider()
         Button(role: .destructive) {
-            deleteFeed(feed)
+            viewModel.deleteFeed(
+                id: feed.id,
+                in: context
+            )
         } label: {
             Label(
                 "Remove Feed",
                 systemImage: "trash"
             )
         }
-    }
-
-    // MARK: - Actions
-
-    private func deleteFeed(_ feed: CDFeed) {
-        context.delete(feed)
-        try? context.save()
     }
 }

--- a/RSSReaderTests/UnitTests/ViewModels/SidebarViewModelCRUDTests.swift
+++ b/RSSReaderTests/UnitTests/ViewModels/SidebarViewModelCRUDTests.swift
@@ -186,4 +186,111 @@ struct SidebarViewModelCRUDTests {
         )
         #expect(feed.folder == nil)
     }
+
+    // MARK: - Feed Deletion
+
+    @Test("deleteFeed removes feed from context")
+    @MainActor
+    func deleteFeedRemovesFeed() throws {
+        let context = CoreDataTestHelper.makeContext()
+        let feed = CDFeed.create(
+            in: context,
+            title: "Test Feed",
+            feedURL: "https://test.com/feed"
+        )
+        try context.save()
+
+        let vm = SidebarViewModel()
+        vm.deleteFeed(id: feed.id, in: context)
+
+        let request = CDFeed.fetchRequest()
+        let feeds = try context.fetch(request)
+        #expect(feeds.isEmpty)
+    }
+
+    @Test("deleteFeed clears selection when deleting selected feed")
+    @MainActor
+    func deleteFeedClearsSelection() throws {
+        let context = CoreDataTestHelper.makeContext()
+        let feed = CDFeed.create(
+            in: context,
+            title: "Test Feed",
+            feedURL: "https://test.com/feed"
+        )
+        try context.save()
+
+        let vm = SidebarViewModel()
+        vm.selection = .feed(feed.id)
+        #expect(vm.selection == .feed(feed.id))
+
+        vm.deleteFeed(id: feed.id, in: context)
+
+        #expect(vm.selection == nil)
+    }
+
+    @Test("deleteFeed preserves selection when deleting different feed")
+    @MainActor
+    func deleteFeedPreservesOtherSelection() throws {
+        let context = CoreDataTestHelper.makeContext()
+        let feed1 = CDFeed.create(
+            in: context,
+            title: "Feed 1",
+            feedURL: "https://test1.com/feed"
+        )
+        let feed2 = CDFeed.create(
+            in: context,
+            title: "Feed 2",
+            feedURL: "https://test2.com/feed"
+        )
+        try context.save()
+
+        let vm = SidebarViewModel()
+        vm.selection = .feed(feed1.id)
+
+        vm.deleteFeed(id: feed2.id, in: context)
+
+        // Selection should still be feed1
+        #expect(vm.selection == .feed(feed1.id))
+
+        // feed2 should be deleted
+        let request = CDFeed.fetchRequest()
+        let feeds = try context.fetch(request)
+        #expect(feeds.count == 1)
+        #expect(feeds.first?.id == feed1.id)
+    }
+
+    @Test("deleteFeed cascades to delete articles")
+    @MainActor
+    func deleteFeedCascadesToArticles() throws {
+        let context = CoreDataTestHelper.makeContext()
+        let feed = CDFeed.create(
+            in: context,
+            title: "Test Feed",
+            feedURL: "https://test.com/feed"
+        )
+        CDArticle.create(
+            in: context,
+            id: "article-1",
+            title: "Article 1",
+            link: "https://test.com/1",
+            published: Date(),
+            feed: feed
+        )
+        CDArticle.create(
+            in: context,
+            id: "article-2",
+            title: "Article 2",
+            link: "https://test.com/2",
+            published: Date(),
+            feed: feed
+        )
+        try context.save()
+
+        let vm = SidebarViewModel()
+        vm.deleteFeed(id: feed.id, in: context)
+
+        let articleRequest = CDArticle.fetchRequest()
+        let articles = try context.fetch(articleRequest)
+        #expect(articles.isEmpty)
+    }
 }


### PR DESCRIPTION
## Summary
- Fixed crash when removing a feed that was added via duplicate OPML import
- Root cause: Selection state was not cleared when deleting a selected feed
- SwiftUI attempted to access deleted Core Data objects causing a crash

## Changes
- Added centralized `deleteFeed(id:in:)` method to SidebarViewModel
- Method clears selection before deletion if the feed is currently selected
- Updated both SidebarFoldersView and SidebarUnfiledFeedsView to use the new method
- Added comprehensive test coverage for feed deletion scenarios

## Test plan
- [ ] Import an OPML file containing duplicate feeds
- [ ] Select one of the duplicate feeds
- [ ] Right-click and select Remove Feed
- [ ] Verify app does not crash
- [ ] Verify selection is cleared
- [ ] Run unit tests: `xcodebuild test -scheme RSSReader -only-testing:RSSReaderTests/UnitTests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)