### PR TITLE
Closes #87: Fix article title formatting issue with Ars Technica

### DIFF
--- a/RSSReader/Utilities/StringExtensions.swift
+++ b/RSSReader/Utilities/StringExtensions.swift
@@ -60,4 +60,19 @@ extension String {
 
         return self
     }
+
+    /// Normalizes whitespace by collapsing newlines and multiple spaces
+    /// into single spaces, then trims leading/trailing whitespace.
+    /// Useful for cleaning up author names and other metadata that may
+    /// contain stray formatting.
+    func normalizingWhitespace() -> String {
+        self
+            .replacingOccurrences(of: "\r\n", with: " ")
+            .replacingOccurrences(of: "\n", with: " ")
+            .replacingOccurrences(of: "\r", with: " ")
+            .replacingOccurrences(of: "\t", with: " ")
+            .components(separatedBy: .whitespaces)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+    }
 }

--- a/RSSReader/Views/ArticleDetail/ArticleDetailView.swift
+++ b/RSSReader/Views/ArticleDetail/ArticleDetailView.swift
@@ -171,7 +171,7 @@ struct ArticleDetailView: View {
         _ article: CDArticle
     ) -> some View {
         HStack(spacing: 12) {
-            if let author = article.author,
+            if let author = article.author?.normalizingWhitespace(),
                !author.isEmpty {
                 Label(author, systemImage: "person")
                     .font(.subheadline)

--- a/RSSReader/Views/ArticleList/ArticleRowView.swift
+++ b/RSSReader/Views/ArticleList/ArticleRowView.swift
@@ -51,7 +51,7 @@ struct ArticleRowView: View {
                 )
 
             HStack {
-                if let author = article.author,
+                if let author = article.author?.normalizingWhitespace(),
                    !author.isEmpty {
                     Text(author)
                         .font(.caption)

--- a/RSSReaderTests/UnitTests/Utilities/StringExtensionsTests.swift
+++ b/RSSReaderTests/UnitTests/Utilities/StringExtensionsTests.swift
@@ -1,0 +1,95 @@
+//
+//  StringExtensionsTests.swift
+//  RSSReaderTests
+//
+//  Created on 2026-02-09.
+//
+
+import Foundation
+import Testing
+@testable import RSSReader
+
+@Suite("String Extensions Tests")
+struct StringExtensionsTests {
+    // MARK: - normalizingWhitespace
+
+    @Test("normalizingWhitespace removes newlines")
+    func normalizingWhitespaceRemovesNewlines() {
+        let input = "John\nDoe"
+        let result = input.normalizingWhitespace()
+        #expect(result == "John Doe")
+    }
+
+    @Test("normalizingWhitespace removes carriage returns")
+    func normalizingWhitespaceRemovesCarriageReturns() {
+        let input = "John\rDoe"
+        let result = input.normalizingWhitespace()
+        #expect(result == "John Doe")
+    }
+
+    @Test("normalizingWhitespace removes CRLF")
+    func normalizingWhitespaceRemovesCRLF() {
+        let input = "John\r\nDoe"
+        let result = input.normalizingWhitespace()
+        #expect(result == "John Doe")
+    }
+
+    @Test("normalizingWhitespace removes tabs")
+    func normalizingWhitespaceRemovesTabs() {
+        let input = "John\tDoe"
+        let result = input.normalizingWhitespace()
+        #expect(result == "John Doe")
+    }
+
+    @Test("normalizingWhitespace collapses multiple spaces")
+    func normalizingWhitespaceCollapsesSpaces() {
+        let input = "John    Doe"
+        let result = input.normalizingWhitespace()
+        #expect(result == "John Doe")
+    }
+
+    @Test("normalizingWhitespace trims leading and trailing")
+    func normalizingWhitespaceTrims() {
+        let input = "  John Doe  "
+        let result = input.normalizingWhitespace()
+        #expect(result == "John Doe")
+    }
+
+    @Test("normalizingWhitespace handles complex case")
+    func normalizingWhitespaceHandlesComplexCase() {
+        // Simulates Ars Technica author format with icon/newline
+        let input = "\n    Kyle Orland\n"
+        let result = input.normalizingWhitespace()
+        #expect(result == "Kyle Orland")
+    }
+
+    @Test("normalizingWhitespace preserves simple strings")
+    func normalizingWhitespacePreservesSimpleStrings() {
+        let input = "John Doe"
+        let result = input.normalizingWhitespace()
+        #expect(result == "John Doe")
+    }
+
+    // MARK: - decodingHTMLEntities
+
+    @Test("decodingHTMLEntities decodes apostrophe")
+    func decodingHTMLEntitiesDecodesApostrophe() {
+        let input = "It&#8217;s a test"
+        let result = input.decodingHTMLEntities()
+        #expect(result.contains("'"))
+    }
+
+    @Test("decodingHTMLEntities decodes ampersand")
+    func decodingHTMLEntitiesDecodesAmpersand() {
+        let input = "Tom &amp; Jerry"
+        let result = input.decodingHTMLEntities()
+        #expect(result == "Tom & Jerry")
+    }
+
+    @Test("decodingHTMLEntities preserves plain strings")
+    func decodingHTMLEntitiesPreservesPlainStrings() {
+        let input = "Hello World"
+        let result = input.decodingHTMLEntities()
+        #expect(result == "Hello World")
+    }
+}


### PR DESCRIPTION
## Summary
- Fixed formatting issue where author names wrapped to a new line in article list
- Root cause: Ars Technica feed includes newline characters in author metadata
- Added whitespace normalization for author display

## Changes
- Added `normalizingWhitespace()` String extension method
- Applied normalization to author display in ArticleRowView and ArticleDetailView
- Added comprehensive unit tests for the new string extension

## Test plan
- [ ] Add the Ars Technica feed: `http://feeds.arstechnica.com/arstechnica/BAaf`
- [ ] Select the feed to load its articles
- [ ] Verify author names display on a single line without line breaks
- [ ] Run unit tests: `xcodebuild test -scheme RSSReader -only-testing:RSSReaderTests/UnitTests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)