### PR TITLE
Closes #84: Add automatic feed refresh on app launch and activation

### DIFF
--- a/RSSReader/Views/ContentView.swift
+++ b/RSSReader/Views/ContentView.swift
@@ -28,7 +28,10 @@ struct ContentView: View {
 
     var body: some View {
         NavigationSplitView {
-            SidebarView(viewModel: sidebarViewModel)
+            SidebarView(
+                viewModel: sidebarViewModel,
+                refreshService: refreshService
+            )
         } content: {
             ArticleListView(
                 sidebarSelection:
@@ -75,6 +78,10 @@ struct ContentView: View {
         .onAppear {
             startAutoRefreshWithSavedInterval()
             setupKeyMonitor()
+            // Trigger initial refresh on app launch
+            Task {
+                await refreshService.refreshAllFeeds()
+            }
         }
         .onDisappear {
             refreshService.stopAutoRefresh()
@@ -102,6 +109,10 @@ struct ContentView: View {
             )
         ) { _ in
             refreshService.resumeAutoRefresh()
+            // Trigger refresh when app becomes active
+            Task {
+                await refreshService.refreshAllFeeds()
+            }
         }
     }
 

--- a/RSSReader/Views/Sidebar/AllArticlesRowView.swift
+++ b/RSSReader/Views/Sidebar/AllArticlesRowView.swift
@@ -9,8 +9,11 @@ import CoreData
 import SwiftUI
 
 /// A row for "All Articles" showing a newspaper icon and
-/// total unread count across all feeds.
+/// total unread count across all feeds, with a spinner when refreshing.
 struct AllArticlesRowView: View {
+    /// Whether feeds are currently being refreshed.
+    var isRefreshing: Bool = false
+
     /// Fetch unread articles directly for accurate real-time count.
     @FetchRequest(
         sortDescriptors: [],
@@ -30,7 +33,11 @@ struct AllArticlesRowView: View {
                     .foregroundStyle(.primary)
             }
             Spacer()
-            if !unreadArticles.isEmpty {
+            if isRefreshing {
+                ProgressView()
+                    .controlSize(.small)
+                    .help("Refreshing feeds...")
+            } else if !unreadArticles.isEmpty {
                 Text("\(unreadArticles.count)")
                     .font(.caption)
                     .fontWeight(.medium)

--- a/RSSReader/Views/Sidebar/SidebarView.swift
+++ b/RSSReader/Views/Sidebar/SidebarView.swift
@@ -21,6 +21,7 @@ extension UTType {
 /// `SidebarViewModel`.
 struct SidebarView: View {
     @ObservedObject var viewModel: SidebarViewModel
+    @ObservedObject var refreshService: RefreshService
 
     @Environment(\.managedObjectContext)
     private var context
@@ -116,7 +117,7 @@ struct SidebarView: View {
 
     @ViewBuilder
     private var allArticlesRow: some View {
-        AllArticlesRowView()
+        AllArticlesRowView(isRefreshing: refreshService.isRefreshing)
             .tag(SidebarSelection.all)
             .onDrop(of: [UTType.feedDrag], isTargeted: nil) { providers in
                 handleDrop(providers: providers, toFolderId: nil)


### PR DESCRIPTION
## Summary
- Automatically trigger feed refresh when the app launches
- Trigger refresh again when the app becomes the active window
- Show a spinner indicator in the sidebar during refresh

## Changes
- **ContentView.swift**: Added `refreshAllFeeds()` calls on `onAppear` and `didBecomeActiveNotification`
- **SidebarView.swift**: Now accepts `RefreshService` to track refresh state
- **AllArticlesRowView.swift**: Displays a `ProgressView` spinner when `isRefreshing` is true

## Test plan
- [ ] Launch the app - feeds should start refreshing immediately with spinner visible
- [ ] Switch away from the app and back - feeds should refresh again
- [ ] Verify spinner disappears when refresh completes
- [ ] Verify unread count reappears after refresh completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)