### PR TITLE
Closes #83: Add sort order toggle for article list

### DIFF
--- a/RSSReader/ViewModels/ArticleListViewModel.swift
+++ b/RSSReader/ViewModels/ArticleListViewModel.swift
@@ -23,6 +23,10 @@ final class ArticleListViewModel: ObservableObject {
     /// When true the view should filter to unread articles.
     @Published var showUnreadOnly = false
 
+    /// When true, articles are sorted newest-first; otherwise oldest-first.
+    /// Defaults to false (oldest-first).
+    @Published var sortNewestFirst = false
+
     /// Indicates a feed refresh is in progress.
     @Published var isLoading = false
 

--- a/RSSReader/Views/ArticleList/ArticleListView.swift
+++ b/RSSReader/Views/ArticleList/ArticleListView.swift
@@ -43,8 +43,10 @@ struct ArticleListView: View {
             for: sidebarSelection,
             showUnreadOnly: viewModel.showUnreadOnly
         )
+        // Default sort order: oldest first (forward)
+        let sortOrder: SortOrder = viewModel.sortNewestFirst ? .reverse : .forward
         _articles = FetchRequest(
-            sortDescriptors: [SortDescriptor(\CDArticle.published, order: .reverse)],
+            sortDescriptors: [SortDescriptor(\CDArticle.published, order: sortOrder)],
             predicate: predicate,
             animation: .default
         )
@@ -87,6 +89,9 @@ struct ArticleListView: View {
         .ignoresSafeArea(.all, edges: .top)
         .onChange(of: viewModel.showUnreadOnly) { _, _ in
             updatePredicate()
+        }
+        .onChange(of: viewModel.sortNewestFirst) { _, newValue in
+            updateSortOrder(newestFirst: newValue)
         }
         .onReceive(NotificationCenter.default.publisher(for: .markAllAsRead)) { _ in
             viewModel.markAllAsRead(Array(articles), in: context)
@@ -175,9 +180,19 @@ struct ArticleListView: View {
         red: 247 / 255, green: 247 / 255, blue: 247 / 255
     )
 
-    /// Capsule control grouping unread filter and refresh buttons.
+    /// Capsule control grouping sort, unread filter, and refresh buttons.
     private var capsuleControls: some View {
         HStack(spacing: 2) {
+            MailStyleButton(
+                isOn: $viewModel.sortNewestFirst,
+                systemImage: "arrow.up.arrow.down"
+            )
+            .help(
+                viewModel.sortNewestFirst
+                    ? "Sort: Newest first (click for oldest first)"
+                    : "Sort: Oldest first (click for newest first)"
+            )
+
             MailStyleButton(
                 isOn: $viewModel.showUnreadOnly,
                 systemImage: "line.3.horizontal.decrease"
@@ -237,7 +252,7 @@ struct ArticleListView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
-    // MARK: - Predicate
+    // MARK: - Predicate & Sort
 
     /// Updates the fetch request predicate for unread filter toggle.
     private func updatePredicate() {
@@ -245,6 +260,14 @@ struct ArticleListView: View {
             for: sidebarSelection,
             showUnreadOnly: viewModel.showUnreadOnly
         )
+    }
+
+    /// Updates the fetch request sort order.
+    private func updateSortOrder(newestFirst: Bool) {
+        let sortOrder: SortOrder = newestFirst ? .reverse : .forward
+        articles.sortDescriptors = [
+            SortDescriptor(\CDArticle.published, order: sortOrder)
+        ]
     }
 }
 


### PR DESCRIPTION
## Summary
- Add a sort order toggle button to the article list header
- Default sort is oldest-first (changed from newest-first)
- Button toggles between oldest-first and newest-first
- Button highlights when in newest-first mode

## Changes
- **ArticleListViewModel.swift**: Added `sortNewestFirst` property (default: false)
- **ArticleListView.swift**: 
  - Added sort toggle button with `arrow.up.arrow.down` SF Symbol
  - Button placed in capsule with filter and refresh buttons
  - Added `updateSortOrder()` to dynamically update fetch request

## Test plan
- [ ] Open article list - verify articles are sorted oldest first by default
- [ ] Click sort button - verify button highlights and articles sort newest first
- [ ] Click sort button again - verify button un-highlights and articles sort oldest first
- [ ] Hover over button - verify tooltip shows current sort state

🤖 Generated with [Claude Code](https://claude.com/claude-code)