### PR TITLE
Closes #82: Improve article reader view formatting

### DIFF
--- a/RSSReader/Utilities/StringExtensions.swift
+++ b/RSSReader/Utilities/StringExtensions.swift
@@ -37,6 +37,60 @@ extension String {
             .trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
+    /// Converts HTML to formatted plain text, preserving paragraph
+    /// structure with double line breaks between paragraphs and
+    /// adding a leading line break if not present.
+    ///
+    /// Inspired by Safari Reader Mode for clean, readable output.
+    func htmlToFormattedText() -> String {
+        // Convert HTML block elements to newlines, then strip tags
+        let text = convertBlockElementsToNewlines().stripHTML()
+
+        // Clean up whitespace while preserving paragraph structure
+        var result = cleanupWhitespace(text)
+
+        // Add leading line break if not empty (for spacing after header)
+        if !result.isEmpty {
+            result = "\n" + result
+        }
+        return result
+    }
+
+    /// Converts HTML block elements to newlines for paragraph preservation.
+    private func convertBlockElementsToNewlines() -> String {
+        var html = self
+        // Replace closing </p> tags with double newline for paragraph spacing
+        html = html.replacingOccurrences(of: "</p>", with: "\n\n", options: .caseInsensitive)
+        // Remove opening <p> tags
+        html = html.replacingOccurrences(of: "<p[^>]*>", with: "", options: .regularExpression)
+        // Convert <br> tags to single newlines
+        html = html.replacingOccurrences(of: "<br\\s*/?>", with: "\n", options: .regularExpression)
+        // Convert block-level closing tags to double newlines
+        html = html.replacingOccurrences(
+            of: "</(?:div|h[1-6]|blockquote|li|tr)>",
+            with: "\n\n",
+            options: .regularExpression
+        )
+        // Add bullet before list items
+        html = html.replacingOccurrences(of: "<li[^>]*>", with: "• ", options: .regularExpression)
+        return html
+    }
+
+    /// Cleans up whitespace while preserving paragraph breaks.
+    private func cleanupWhitespace(_ text: String) -> String {
+        var result = text.replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
+        // Collapse 3+ newlines to 2
+        while result.contains("\n\n\n") {
+            result = result.replacingOccurrences(of: "\n\n\n", with: "\n\n")
+        }
+        // Trim each line
+        result = result.split(separator: "\n", omittingEmptySubsequences: false)
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .joined(separator: "\n")
+        return result.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
     /// Decodes HTML entities like &#8217; to their proper characters.
     func decodingHTMLEntities() -> String {
         guard contains("&") else { return self }

--- a/RSSReader/ViewModels/ArticleDetailViewModel.swift
+++ b/RSSReader/ViewModels/ArticleDetailViewModel.swift
@@ -48,6 +48,17 @@ final class ArticleDetailViewModel: ObservableObject {
         return raw.stripHTML()
     }
 
+    /// Returns the article body with preserved paragraph formatting,
+    /// inspired by Safari Reader Mode. Prefers `content` over `summary`.
+    func formattedContent(
+        for article: CDArticle
+    ) -> String {
+        let raw = article.content
+            ?? article.summary
+            ?? ""
+        return raw.htmlToFormattedText()
+    }
+
     // MARK: - Actions
 
     /// Marks the article as read in Core Data if it is

--- a/RSSReader/Views/ArticleDetail/ArticleDetailView.swift
+++ b/RSSReader/Views/ArticleDetail/ArticleDetailView.swift
@@ -201,23 +201,27 @@ struct ArticleDetailView: View {
 
     // MARK: - Body Text
 
+    /// Reader-mode style body font (slightly larger than system body)
+    private static let readerFont = Font.system(size: 16)
+
     private func bodyText(
         _ article: CDArticle
     ) -> some View {
-        let text = viewModel.plainTextContent(
+        let text = viewModel.formattedContent(
             for: article
         )
 
         return Group {
-            if text.isEmpty {
+            if text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                 Text("No content available.")
                     .foregroundStyle(.tertiary)
                     .italic()
             } else {
                 Text(text)
-                    .font(.body)
-                    .lineSpacing(6)
+                    .font(Self.readerFont)
+                    .lineSpacing(8)
                     .textSelection(.enabled)
+                    .frame(maxWidth: 700, alignment: .leading)
             }
         }
     }


### PR DESCRIPTION
## Summary
- Improve article readability with Safari Reader Mode-inspired formatting
- Preserve HTML paragraph structure instead of stripping all formatting
- Apply cleaner typography with better font sizing and line spacing

## Changes
- **StringExtensions.swift**: 
  - Added `htmlToFormattedText()` method to preserve paragraph structure
  - Converts `<p>`, `<br>`, `<div>`, `<blockquote>` to proper line breaks
  - Converts `<li>` elements to bullet points
  - Cleans up excessive whitespace while preserving paragraph spacing
  - Adds leading line break for spacing after article header
  
- **ArticleDetailViewModel.swift**: 
  - Added `formattedContent()` method that uses the new formatter
  
- **ArticleDetailView.swift**: 
  - Use formatted content instead of plain text
  - Increase body font size to 16pt for readability
  - Increase line spacing to 8pt
  - Limit content width to 700pt for optimal reading line length

## Test plan
- [ ] Open an article with multiple paragraphs - verify paragraphs are properly spaced
- [ ] Open an article with bullet lists - verify bullets render correctly
- [ ] Verify leading line break appears after the article header
- [ ] Verify the content is constrained to a comfortable reading width
- [ ] Verify text is easier to read with larger font and spacing

🤖 Generated with [Claude Code](https://claude.com/claude-code)