### PR TITLE
Closes #22: Add integration tests and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,129 @@
+# Syndicate
 
-## AI Agent Team
+A native macOS RSS reader that fetches and parses RSS/Atom feeds directly, storing all data locally with Core Data. Focused on keyboard-driven navigation and efficient reading workflows.
 
-### Agents
+## Features
 
-1. **Architect** - Technical design and architecture
-2. **Scrum Master** - Story breakdown and sprint planning
-3. **Engineer** - Code implementation
-4. **QA** - Quality assurance and testing
-5. **DevOps** - CI/CD pipelines and build automation
+- **Local-first:** No cloud dependencies, all data stored locally
+- **Direct feed parsing:** Parses RSS/Atom feeds directly via FeedKit
+- **Native macOS:** Built with SwiftUI, follows Human Interface Guidelines
+- **Keyboard-first:** Efficient navigation without mouse
+- **OPML Support:** Import/export subscriptions for easy migration
 
-### Agent Usage
-```bash
-# DevOps examples
-./run-agent.sh devops "Create GitHub Actions workflow for PR validation"
-./run-agent.sh devops "Optimize build times with caching"
-./run-agent.sh devops "Setup automated releases"
+## Requirements
+
+- macOS 14.0+ (Sonoma)
+- Xcode 15+
+- Swift 5.9+
+
+## Getting Started
+
+### Installation
+
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/DanGahan/rss-reader.git
+   cd rss-reader
+   ```
+
+2. Open the project in Xcode:
+   ```bash
+   open RSSReader.xcodeproj
+   ```
+
+3. Build and run (Cmd+R)
+
+### Migrating from Feedly
+
+1. In Feedly: Settings > Import/Export > Export OPML
+2. Save the `feedly-export.opml` file
+3. In Syndicate: File > Import Subscriptions
+4. Select the OPML file
+5. Choose which feeds to import and their folder destinations
+6. Click Import
+
+Note: Read/unread status does not migrate from Feedly.
+
+## Keyboard Shortcuts
+
+| Key | Action |
+|-----|--------|
+| `n` | Next article |
+| `j` | Next article (vim-style) |
+| `k` | Previous article (vim-style) |
+| `Enter/Space` | Open article in Safari |
+| `Cmd+R` | Refresh all feeds |
+| `Cmd+N` | Add new feed |
+| `Cmd+Shift+N` | New folder |
+| `Cmd+,` | Open settings |
+
+## Architecture
+
+The app follows the MVVM pattern:
+
+```
+SwiftUI Views -> ViewModels -> Service Layer -> Core Data
+                               |-- FeedParserService
+                               |-- RefreshService
+                               |-- OPMLService
+                               +-- ArticleCleanupService
 ```
 
-### Agent Permissions
+### Key Components
 
-Each agent has carefully scoped command permissions:
+- **FeedParserService:** Parses RSS 2.0, RSS 1.0, and Atom feeds using FeedKit
+- **RefreshService:** Manages manual and automatic feed refresh with concurrency control
+- **OPMLService:** Handles OPML import/export for feed migration
+- **ArticleCleanupService:** Manages article retention (30 days / 1000 per feed)
+- **PersistenceController:** Core Data stack management
 
-- **Architect:** Read-only + documentation creation
-- **Scrum Master:** GitHub issue/label management
-- **Engineer:** Full dev workflow (branch, commit, PR)
-- **QA:** Testing + PR review
-- **DevOps:** Pipeline management + build automation
+## Development
+
+### Running Tests
+
+```bash
+xcodebuild test -scheme RSSReader -destination 'platform=macOS'
+```
+
+### SwiftLint
+
+The project uses SwiftLint for code style. Run locally:
+
+```bash
+swiftlint lint
+```
+
+### Project Structure
+
+```
+RSSReader/
+  App/           # App entry point, keyboard commands
+  Models/        # Core Data models and entities
+  Services/      # Business logic services
+  ViewModels/    # MVVM view models
+  Views/         # SwiftUI views
+  Utilities/     # Extensions and helpers
+RSSReaderTests/
+  UnitTests/     # Unit tests for models, services, viewmodels
+  IntegrationTests/  # Integration tests
+```
+
+## Known Limitations
+
+- **No sync:** Data is stored locally only; no iCloud sync in MVP
+- **No full-text search:** Search functionality not yet implemented
+- **No article starring:** Favoriting articles not yet available
+- **Basic content display:** Article content shown as formatted text, no full web rendering
+- **No feed discovery:** Must enter exact feed URL, no auto-discovery from website URLs
+
+## Contributing
+
+1. Create a feature branch: `git checkout -b feature/issue-X-description`
+2. Make your changes following the code standards in `docs/STANDARDS.md`
+3. Run tests: `xcodebuild test -scheme RSSReader`
+4. Run SwiftLint: `swiftlint lint`
+5. Create a PR with a clear description
+
+## License
+
+MIT License - see LICENSE file for details.

--- a/RSSReaderTests/IntegrationTests/CoreDataIntegrationTests.swift
+++ b/RSSReaderTests/IntegrationTests/CoreDataIntegrationTests.swift
@@ -1,0 +1,243 @@
+//
+//  CoreDataIntegrationTests.swift
+//  RSSReaderTests
+//
+//  Integration tests for Core Data CRUD operations.
+//
+
+import CoreData
+import XCTest
+@testable import RSSReader
+
+final class CoreDataIntegrationTests: XCTestCase {
+    var persistence: PersistenceController!
+    var context: NSManagedObjectContext!
+
+    override func setUp() {
+        super.setUp()
+        persistence = PersistenceController.inMemory()
+        context = persistence.viewContext
+    }
+
+    override func tearDown() {
+        context = nil
+        persistence = nil
+        super.tearDown()
+    }
+
+    // MARK: - Folder CRUD
+
+    func testCreateFolder() throws {
+        let folder = CDFolder(context: context)
+        folder.id = UUID()
+        folder.name = "Tech News"
+        folder.sortOrder = 0
+        folder.dateCreated = Date()
+
+        try context.save()
+
+        let request = CDFolder.fetchRequest()
+        let folders = try context.fetch(request)
+
+        XCTAssertEqual(folders.count, 1)
+        XCTAssertEqual(folders.first?.name, "Tech News")
+    }
+
+    func testUpdateFolder() throws {
+        let folder = CDFolder(context: context)
+        folder.id = UUID()
+        folder.name = "Original Name"
+        folder.sortOrder = 0
+        folder.dateCreated = Date()
+        try context.save()
+
+        folder.name = "Updated Name"
+        try context.save()
+
+        let request = CDFolder.fetchRequest()
+        let folders = try context.fetch(request)
+        XCTAssertEqual(folders.first?.name, "Updated Name")
+    }
+
+    func testDeleteFolder() throws {
+        let folder = CDFolder(context: context)
+        folder.id = UUID()
+        folder.name = "To Delete"
+        folder.sortOrder = 0
+        folder.dateCreated = Date()
+        try context.save()
+
+        context.delete(folder)
+        try context.save()
+
+        let request = CDFolder.fetchRequest()
+        let folders = try context.fetch(request)
+        XCTAssertEqual(folders.count, 0)
+    }
+
+    // MARK: - Feed CRUD
+
+    func testCreateFeed() throws {
+        let feed = CDFeed(context: context)
+        feed.id = UUID()
+        feed.title = "Ars Technica"
+        feed.feedURL = "https://feeds.arstechnica.com/arstechnica/index"
+        feed.dateAdded = Date()
+
+        try context.save()
+
+        let request = CDFeed.fetchRequest()
+        let feeds = try context.fetch(request)
+
+        XCTAssertEqual(feeds.count, 1)
+        XCTAssertEqual(feeds.first?.title, "Ars Technica")
+    }
+
+    func testFeedWithFolder() throws {
+        let folder = CDFolder(context: context)
+        folder.id = UUID()
+        folder.name = "Tech"
+        folder.sortOrder = 0
+        folder.dateCreated = Date()
+
+        let feed = CDFeed(context: context)
+        feed.id = UUID()
+        feed.title = "Test Feed"
+        feed.feedURL = "https://example.com/feed"
+        feed.dateAdded = Date()
+        feed.folder = folder
+
+        try context.save()
+
+        let request = CDFeed.fetchRequest()
+        let feeds = try context.fetch(request)
+
+        XCTAssertEqual(feeds.first?.folder?.name, "Tech")
+    }
+
+    // MARK: - Article CRUD
+
+    func testCreateArticle() throws {
+        let feed = CDFeed(context: context)
+        feed.id = UUID()
+        feed.title = "Test Feed"
+        feed.feedURL = "https://example.com/feed"
+        feed.dateAdded = Date()
+
+        let article = CDArticle(context: context)
+        article.id = "article-1"
+        article.title = "Test Article"
+        article.link = "https://example.com/article/1"
+        article.published = Date()
+        article.dateAdded = Date()
+        article.isRead = false
+        article.feed = feed
+
+        try context.save()
+
+        let request = CDArticle.fetchRequest()
+        let articles = try context.fetch(request)
+
+        XCTAssertEqual(articles.count, 1)
+        XCTAssertEqual(articles.first?.title, "Test Article")
+        XCTAssertEqual(articles.first?.feed?.title, "Test Feed")
+    }
+
+    func testMarkArticleAsRead() throws {
+        let feed = CDFeed(context: context)
+        feed.id = UUID()
+        feed.title = "Test Feed"
+        feed.feedURL = "https://example.com/feed"
+        feed.dateAdded = Date()
+
+        let article = CDArticle(context: context)
+        article.id = "article-1"
+        article.title = "Test Article"
+        article.link = "https://example.com/article/1"
+        article.published = Date()
+        article.dateAdded = Date()
+        article.isRead = false
+        article.feed = feed
+
+        try context.save()
+
+        XCTAssertFalse(article.isRead)
+
+        article.isRead = true
+        try context.save()
+
+        let request = CDArticle.fetchRequest()
+        let articles = try context.fetch(request)
+        XCTAssertTrue(articles.first?.isRead ?? false)
+    }
+
+    // MARK: - Cascade Delete
+
+    func testDeleteFeedCascadesToArticles() throws {
+        let feed = CDFeed(context: context)
+        feed.id = UUID()
+        feed.title = "Test Feed"
+        feed.feedURL = "https://example.com/feed"
+        feed.dateAdded = Date()
+
+        let article1 = CDArticle(context: context)
+        article1.id = "article-1"
+        article1.title = "Article 1"
+        article1.link = "https://example.com/1"
+        article1.published = Date()
+        article1.dateAdded = Date()
+        article1.isRead = false
+        article1.feed = feed
+
+        let article2 = CDArticle(context: context)
+        article2.id = "article-2"
+        article2.title = "Article 2"
+        article2.link = "https://example.com/2"
+        article2.published = Date()
+        article2.dateAdded = Date()
+        article2.isRead = false
+        article2.feed = feed
+
+        try context.save()
+
+        let articleRequest = CDArticle.fetchRequest()
+        XCTAssertEqual(try context.fetch(articleRequest).count, 2)
+
+        context.delete(feed)
+        try context.save()
+
+        XCTAssertEqual(try context.fetch(articleRequest).count, 0)
+    }
+
+    // MARK: - Unread Count Queries
+
+    func testUnreadCountPerFeed() throws {
+        let feed = CDFeed(context: context)
+        feed.id = UUID()
+        feed.title = "Test Feed"
+        feed.feedURL = "https://example.com/feed"
+        feed.dateAdded = Date()
+
+        for i in 1...5 {
+            let article = CDArticle(context: context)
+            article.id = "article-\(i)"
+            article.title = "Article \(i)"
+            article.link = "https://example.com/\(i)"
+            article.published = Date()
+            article.dateAdded = Date()
+            article.isRead = i <= 2  // First 2 are read
+            article.feed = feed
+        }
+
+        try context.save()
+
+        let request = CDArticle.fetchRequest()
+        request.predicate = NSPredicate(
+            format: "feed == %@ AND isRead == NO",
+            feed
+        )
+        let unreadCount = try context.count(for: request)
+
+        XCTAssertEqual(unreadCount, 3)
+    }
+}

--- a/RSSReaderTests/IntegrationTests/IntegrationTestsPlaceholder.swift
+++ b/RSSReaderTests/IntegrationTests/IntegrationTestsPlaceholder.swift
@@ -1,8 +1,0 @@
-//
-//  IntegrationTestsPlaceholder.swift
-//  RSSReaderTests
-//
-//  Created on 2026-01-28.
-//
-
-// Integration tests will be added in story #22.

--- a/RSSReaderTests/IntegrationTests/OPMLIntegrationTests.swift
+++ b/RSSReaderTests/IntegrationTests/OPMLIntegrationTests.swift
@@ -1,0 +1,211 @@
+//
+//  OPMLIntegrationTests.swift
+//  RSSReaderTests
+//
+//  Integration tests for OPML import/export pipeline.
+//
+
+import CoreData
+import XCTest
+@testable import RSSReader
+
+final class OPMLIntegrationTests: XCTestCase {
+    var persistence: PersistenceController!
+    var context: NSManagedObjectContext!
+    var opmlService: OPMLService!
+
+    override func setUp() {
+        super.setUp()
+        persistence = PersistenceController.inMemory()
+        context = persistence.viewContext
+        opmlService = OPMLService()
+    }
+
+    override func tearDown() {
+        opmlService = nil
+        context = nil
+        persistence = nil
+        super.tearDown()
+    }
+
+    // MARK: - Import -> Create -> Verify
+
+    // swiftlint:disable line_length
+    func testImportOPMLCreatesFeedsAndFolders() throws {
+        let opmlContent = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <opml version="2.0">
+        <head><title>Test Export</title></head>
+        <body>
+            <outline text="Tech" title="Tech">
+                <outline type="rss" text="Ars Technica" xmlUrl="https://feeds.arstechnica.com/arstechnica/index"/>
+                <outline type="rss" text="The Verge" xmlUrl="https://www.theverge.com/rss/index.xml"/>
+            </outline>
+            <outline type="rss" text="BBC News" xmlUrl="http://feeds.bbci.co.uk/news/rss.xml"/>
+        </body>
+        </opml>
+        """
+    // swiftlint:enable line_length
+
+        guard let data = opmlContent.data(using: .utf8) else {
+            XCTFail("Failed to create OPML data")
+            return
+        }
+
+        // Import OPML
+        let document = try opmlService.parseOPML(from: data)
+
+        // Verify parsed structure
+        XCTAssertEqual(document.folders.count, 1)
+        XCTAssertEqual(document.folders.first?.name, "Tech")
+        XCTAssertEqual(document.folders.first?.feeds.count, 2)
+        XCTAssertEqual(document.unfiledFeeds.count, 1)
+        XCTAssertTrue(document.unfiledFeeds.first?.title.contains("BBC") ?? false)
+
+        // Create in Core Data
+        let folder = CDFolder(context: context)
+        folder.id = UUID()
+        folder.name = document.folders.first?.name ?? ""
+        folder.sortOrder = 0
+        folder.dateCreated = Date()
+
+        for opmlFeed in document.folders.first?.feeds ?? [] {
+            let feed = CDFeed(context: context)
+            feed.id = UUID()
+            feed.title = opmlFeed.title
+            feed.feedURL = opmlFeed.feedURL
+            feed.siteURL = opmlFeed.siteURL
+            feed.dateAdded = Date()
+            feed.folder = folder
+        }
+
+        for opmlFeed in document.unfiledFeeds {
+            let feed = CDFeed(context: context)
+            feed.id = UUID()
+            feed.title = opmlFeed.title
+            feed.feedURL = opmlFeed.feedURL
+            feed.siteURL = opmlFeed.siteURL
+            feed.dateAdded = Date()
+        }
+
+        try context.save()
+
+        // Verify Core Data
+        let folderRequest = CDFolder.fetchRequest()
+        let folders = try context.fetch(folderRequest)
+        XCTAssertEqual(folders.count, 1)
+        XCTAssertEqual(folders.first?.name, "Tech")
+
+        let feedRequest = CDFeed.fetchRequest()
+        let feeds = try context.fetch(feedRequest)
+        XCTAssertEqual(feeds.count, 3)
+
+        let techFeeds = feeds.filter { $0.folder != nil }
+        XCTAssertEqual(techFeeds.count, 2)
+
+        let unfiledFeeds = feeds.filter { $0.folder == nil }
+        XCTAssertEqual(unfiledFeeds.count, 1)
+    }
+
+    // MARK: - Export -> Re-Import Roundtrip
+
+    func testExportAndReimportRoundtrip() throws {
+        // Create test data
+        let folder = CDFolder(context: context)
+        folder.id = UUID()
+        folder.name = "News"
+        folder.sortOrder = 0
+        folder.dateCreated = Date()
+
+        let feed1 = CDFeed(context: context)
+        feed1.id = UUID()
+        feed1.title = "Test Feed 1"
+        feed1.feedURL = "https://example.com/feed1.xml"
+        feed1.siteURL = "https://example.com"
+        feed1.dateAdded = Date()
+        feed1.folder = folder
+
+        let feed2 = CDFeed(context: context)
+        feed2.id = UUID()
+        feed2.title = "Unfiled Feed"
+        feed2.feedURL = "https://example.org/feed.xml"
+        feed2.dateAdded = Date()
+
+        try context.save()
+
+        // Export
+        let exportedData = try opmlService.exportOPML(from: context)
+        XCTAssertFalse(exportedData.isEmpty)
+
+        // Verify export contains expected content
+        let exportedString = String(data: exportedData, encoding: .utf8)!
+        XCTAssertTrue(exportedString.contains("Syndicate Export"))
+        XCTAssertTrue(exportedString.contains("Test Feed 1"))
+        XCTAssertTrue(exportedString.contains("Unfiled Feed"))
+        XCTAssertTrue(exportedString.contains("News"))
+
+        // Re-import into fresh context
+        let persistence2 = PersistenceController.inMemory()
+        let context2 = persistence2.viewContext
+
+        let document = try opmlService.parseOPML(from: exportedData)
+
+        // Verify re-imported structure matches
+        XCTAssertEqual(document.folders.count, 1)
+        XCTAssertEqual(document.folders.first?.name, "News")
+        XCTAssertEqual(document.folders.first?.feeds.count, 1)
+        XCTAssertEqual(document.unfiledFeeds.count, 1)
+
+        // Create in new context
+        for opmlFolder in document.folders {
+            let newFolder = CDFolder(context: context2)
+            newFolder.id = UUID()
+            newFolder.name = opmlFolder.name
+            newFolder.sortOrder = 0
+            newFolder.dateCreated = Date()
+
+            for opmlFeed in opmlFolder.feeds {
+                let newFeed = CDFeed(context: context2)
+                newFeed.id = UUID()
+                newFeed.title = opmlFeed.title
+                newFeed.feedURL = opmlFeed.feedURL
+                newFeed.dateAdded = Date()
+                newFeed.folder = newFolder
+            }
+        }
+
+        for opmlFeed in document.unfiledFeeds {
+            let newFeed = CDFeed(context: context2)
+            newFeed.id = UUID()
+            newFeed.title = opmlFeed.title
+            newFeed.feedURL = opmlFeed.feedURL
+            newFeed.dateAdded = Date()
+        }
+
+        try context2.save()
+
+        // Verify final state
+        let feedRequest = CDFeed.fetchRequest()
+        let feeds = try context2.fetch(feedRequest)
+        XCTAssertEqual(feeds.count, 2)
+    }
+
+    // MARK: - Malformed OPML
+
+    func testMalformedOPMLThrowsError() {
+        let malformedContent = """
+        <?xml version="1.0"?>
+        <opml version="2.0">
+        <head><title>Bad OPML</title></head>
+        <!-- Missing body tag -->
+        </opml>
+        """
+
+        guard let data = malformedContent.data(using: .utf8) else {
+            XCTFail("Failed to create data")
+            return
+        }
+
+        XCTAssertThrowsError(try opmlService.parseOPML(from: data))
+    }
+}


### PR DESCRIPTION
## Summary
- Add comprehensive README with setup instructions and documentation
- Add integration tests for Core Data and OPML pipelines
- Document known limitations and architecture

## Changes

### README.md
- Complete rewrite with proper project documentation
- Setup and installation instructions
- Migration guide from Feedly
- Keyboard shortcuts reference
- Architecture overview
- Development guidelines
- Known limitations documented

### Integration Tests
- **CoreDataIntegrationTests.swift**: 
  - Folder CRUD operations
  - Feed CRUD operations  
  - Article CRUD operations
  - Feed-folder relationships
  - Cascade delete verification
  - Unread count queries

- **OPMLIntegrationTests.swift**:
  - OPML import -> Core Data creation -> verification pipeline
  - Export -> re-import roundtrip test
  - Malformed OPML error handling

## Test plan
- [ ] Run `xcodebuild test -scheme RSSReader` - verify all tests pass
- [ ] Review README for accuracy and completeness
- [ ] Verify known limitations are accurate

## Acceptance Criteria Status
- [x] FeedParserService unit tests (existing)
- [x] RefreshService unit tests (existing)
- [x] OPMLService unit tests (existing)
- [x] ArticleCleanupService unit tests (existing)
- [x] Core Data CRUD integration tests (NEW)
- [x] OPML import-create-verify integration test (NEW)
- [x] README.md with setup instructions (NEW)
- [x] Known limitations documented (NEW)

🤖 Generated with [Claude Code](https://claude.com/claude-code)