### PR TITLE
Closes #105: Add rich text formatting for article content

### DIFF
--- a/RSSReader.xcodeproj/project.pbxproj
+++ b/RSSReader.xcodeproj/project.pbxproj
@@ -954,7 +954,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = "0.0.1-alpha";
+				MARKETING_VERSION = "0.0.2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.syndicate.app;
 				PRODUCT_MODULE_NAME = RSSReader;
 				PRODUCT_NAME = Syndicate;
@@ -989,7 +989,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = "0.0.1-alpha";
+				MARKETING_VERSION = "0.0.2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.syndicate.app;
 				PRODUCT_MODULE_NAME = RSSReader;
 				PRODUCT_NAME = Syndicate;

--- a/RSSReader.xcodeproj/project.pbxproj
+++ b/RSSReader.xcodeproj/project.pbxproj
@@ -7,10 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3636756C9C9F2C7B6DA4B712 /* RichTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A48BDA6BB02DDDF5252D6DD /* RichTextView.swift */; };
 		36D917EE3D5BD7D17D8BBB2F /* FolderNameSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4756FE84A2A91578025301D2 /* FolderNameSheet.swift */; };
-		AAAAAA01DEADBEEF00000001 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AAAAAA02DEADBEEF00000001 /* Assets.xcassets */; };
-		BBBBBB01DEADBEEF00000001 /* Syndicate.icon in Resources */ = {isa = PBXBuildFile; fileRef = BBBBBB02DEADBEEF00000001 /* Syndicate.icon */; };
 		37037A842F33ECD600245B95 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37037A832F33ECD600245B95 /* SettingsView.swift */; };
+		54FFA2A46DD9570E6F6DA36B /* HTMLAttributedStringConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8BDDAA1239CC115403F1FCA /* HTMLAttributedStringConverterTests.swift */; };
+		6A99B7C275F21DD6F6649CE0 /* HTMLSanitizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE75C6A7C3E5B349FC0C3C50 /* HTMLSanitizer.swift */; };
+		70A48A0308CDE02D22895C5A /* HTMLAttributedStringConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D0DDE8B964CB4007B347D07 /* HTMLAttributedStringConverter.swift */; };
 		A1000001 /* SyndicateApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000001 /* SyndicateApp.swift */; };
 		A1000002 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000002 /* AppState.swift */; };
 		A1000003 /* KeyboardCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000003 /* KeyboardCommands.swift */; };
@@ -96,7 +98,9 @@
 		A1000170C /* FeedParserServiceJSONParsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000170C /* FeedParserServiceJSONParsingTests.swift */; };
 		A1000180 /* AddFeedSheetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000180 /* AddFeedSheetTests.swift */; };
 		A1000181 /* ContentViewLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000181 /* ContentViewLayoutTests.swift */; };
+		AAAAAA01DEADBEEF00000001 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AAAAAA02DEADBEEF00000001 /* Assets.xcassets */; };
 		BA6AC78B436740B553E58F60 /* ImportOPMLViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71580E74704C862B24CED8D4 /* ImportOPMLViewModel.swift */; };
+		E49F5E8988E8D2EE78DEBE90 /* HTMLSanitizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202CE4E0BDF6A69EC817C9DC /* HTMLSanitizerTests.swift */; };
 		F70ECE0C1940A7B9106B1811 /* ImportOPMLWizard.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA525B0747B598B613FDFCB3 /* ImportOPMLWizard.swift */; };
 /* End PBXBuildFile section */
 
@@ -118,11 +122,12 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		202CE4E0BDF6A69EC817C9DC /* HTMLSanitizerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HTMLSanitizerTests.swift; sourceTree = "<group>"; };
 		37037A832F33ECD600245B95 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SettingsView.swift; path = Settings/SettingsView.swift; sourceTree = "<group>"; };
-		AAAAAA02DEADBEEF00000001 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
-		BBBBBB02DEADBEEF00000001 /* Syndicate.icon */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Syndicate.icon; sourceTree = SOURCE_ROOT; };
 		4756FE84A2A91578025301D2 /* FolderNameSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FolderNameSheet.swift; sourceTree = "<group>"; };
+		6D0DDE8B964CB4007B347D07 /* HTMLAttributedStringConverter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HTMLAttributedStringConverter.swift; sourceTree = "<group>"; };
 		71580E74704C862B24CED8D4 /* ImportOPMLViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ImportOPMLViewModel.swift; sourceTree = "<group>"; };
+		9A48BDA6BB02DDDF5252D6DD /* RichTextView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RichTextView.swift; sourceTree = "<group>"; };
 		A2000001 /* SyndicateApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyndicateApp.swift; sourceTree = "<group>"; };
 		A2000002 /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
 		A2000003 /* KeyboardCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardCommands.swift; sourceTree = "<group>"; };
@@ -212,6 +217,10 @@
 		A2100002 /* RSSReaderTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RSSReaderTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A2100003 /* RSSReaderUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RSSReaderUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AA525B0747B598B613FDFCB3 /* ImportOPMLWizard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ImportOPMLWizard.swift; sourceTree = "<group>"; };
+		AAAAAA02DEADBEEF00000001 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		BBBBBB02DEADBEEF00000001 /* Syndicate.icon */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Syndicate.icon; sourceTree = SOURCE_ROOT; };
+		C8BDDAA1239CC115403F1FCA /* HTMLAttributedStringConverterTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HTMLAttributedStringConverterTests.swift; path = Utilities/HTMLAttributedStringConverterTests.swift; sourceTree = "<group>"; };
+		CE75C6A7C3E5B349FC0C3C50 /* HTMLSanitizer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HTMLSanitizer.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -240,6 +249,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		577291694187B1E5667361E8 /* Utilities */ = {
+			isa = PBXGroup;
+			children = (
+				C8BDDAA1239CC115403F1FCA /* HTMLAttributedStringConverterTests.swift */,
+			);
+			name = Utilities;
+			sourceTree = "<group>";
+		};
 		A7000000 = {
 			isa = PBXGroup;
 			children = (
@@ -367,6 +384,7 @@
 				A2000119 /* RetryPolicy.swift */,
 				A200011A /* ErrorLogger.swift */,
 				A200011B /* RefreshService.swift */,
+				CE75C6A7C3E5B349FC0C3C50 /* HTMLSanitizer.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -375,6 +393,7 @@
 			isa = PBXGroup;
 			children = (
 				A2000060 /* StringExtensions.swift */,
+				6D0DDE8B964CB4007B347D07 /* HTMLAttributedStringConverter.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -392,6 +411,7 @@
 			isa = PBXGroup;
 			children = (
 				A2000132 /* ArticleDetailView.swift */,
+				9A48BDA6BB02DDDF5252D6DD /* RichTextView.swift */,
 			);
 			path = ArticleDetail;
 			sourceTree = "<group>";
@@ -418,6 +438,7 @@
 				A7000023 /* ViewModels */,
 				A7000024 /* Services */,
 				A7000025 /* Views */,
+				577291694187B1E5667361E8 /* Utilities */,
 			);
 			path = UnitTests;
 			sourceTree = "<group>";
@@ -479,6 +500,7 @@
 				A2000169 /* RSSReaderErrorTests.swift */,
 				A200016A /* RetryPolicyTests.swift */,
 				A200016B /* RefreshServiceTests.swift */,
+				202CE4E0BDF6A69EC817C9DC /* HTMLSanitizerTests.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -710,6 +732,9 @@
 				F70ECE0C1940A7B9106B1811 /* ImportOPMLWizard.swift in Sources */,
 				BA6AC78B436740B553E58F60 /* ImportOPMLViewModel.swift in Sources */,
 				36D917EE3D5BD7D17D8BBB2F /* FolderNameSheet.swift in Sources */,
+				6A99B7C275F21DD6F6649CE0 /* HTMLSanitizer.swift in Sources */,
+				70A48A0308CDE02D22895C5A /* HTMLAttributedStringConverter.swift in Sources */,
+				3636756C9C9F2C7B6DA4B712 /* RichTextView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -752,6 +777,8 @@
 				A1000180 /* AddFeedSheetTests.swift in Sources */,
 				A1000181 /* ContentViewLayoutTests.swift in Sources */,
 				A1000170 /* IntegrationTestsPlaceholder.swift in Sources */,
+				E49F5E8988E8D2EE78DEBE90 /* HTMLSanitizerTests.swift in Sources */,
+				54FFA2A46DD9570E6F6DA36B /* HTMLAttributedStringConverterTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -904,8 +931,8 @@
 		AB000011 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_APPICON_NAME = Syndicate;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
 				CODE_SIGN_ENTITLEMENTS = RSSReader/RSSReader.entitlements;
 				CODE_SIGN_STYLE = Automatic;
@@ -939,8 +966,8 @@
 		AB000012 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_APPICON_NAME = Syndicate;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
 				CODE_SIGN_ENTITLEMENTS = RSSReader/RSSReader.entitlements;
 				CODE_SIGN_STYLE = Automatic;

--- a/RSSReader/Services/HTMLSanitizer.swift
+++ b/RSSReader/Services/HTMLSanitizer.swift
@@ -1,0 +1,167 @@
+//
+//  HTMLSanitizer.swift
+//  RSSReader
+//
+//  Created on 2026-02-10.
+//
+
+import Foundation
+
+/// Sanitizes HTML content by removing dangerous elements while preserving
+/// safe formatting tags for rich text display.
+///
+/// Uses an allow-list approach: only explicitly allowed tags are preserved,
+/// all others are removed. Dangerous attributes are stripped from all tags.
+struct HTMLSanitizer {
+    /// Tags allowed to pass through sanitization.
+    static let allowedTags: Set<String> = [
+        "p", "br",
+        "ul", "ol", "li",
+        "b", "strong", "i", "em",
+        "blockquote",
+        "h1", "h2", "h3", "h4", "h5", "h6",
+        "pre", "code",
+        "a"
+    ]
+
+    /// Tags that should be completely removed including their content.
+    static let dangerousTags: Set<String> = [
+        "script", "style", "iframe", "object", "embed",
+        "form", "input", "textarea", "button", "select"
+    ]
+
+    /// Attributes that are always removed (security risk).
+    private static let dangerousAttributePatterns: [String] = [
+        "on\\w+",  // All event handlers (onclick, onload, etc.)
+        "style",
+        "class",
+        "id"
+    ]
+
+    /// Safe attributes that can be preserved on allowed tags.
+    private static let safeAttributes: Set<String> = [
+        "href"  // For links
+    ]
+
+    /// Sanitizes HTML string, removing dangerous elements.
+    ///
+    /// - Parameter html: The HTML string to sanitize.
+    /// - Returns: Sanitized HTML with only safe tags and attributes.
+    func sanitize(_ html: String) -> String {
+        var result = html
+
+        // Step 1: Remove dangerous tags and their content entirely
+        result = removeDangerousTags(result)
+
+        // Step 2: Remove dangerous attributes from remaining tags
+        result = removeDangerousAttributes(result)
+
+        // Step 3: Remove tags not in the allow-list (but keep their content)
+        result = removeDisallowedTags(result)
+
+        return result
+    }
+
+    // MARK: - Private Helpers
+
+    /// Removes dangerous tags and all their content.
+    private func removeDangerousTags(_ html: String) -> String {
+        var result = html
+
+        for tag in Self.dangerousTags {
+            // Match opening tag, content, and closing tag (case insensitive)
+            // Handle self-closing variants too
+            let patterns = [
+                "<\(tag)[^>]*>.*?</\(tag)>",  // With content
+                "<\(tag)[^>]*/?>",             // Self-closing
+                "</\(tag)>"                    // Orphan closing
+            ]
+
+            for pattern in patterns {
+                if let regex = try? NSRegularExpression(
+                    pattern: pattern,
+                    options: [.caseInsensitive, .dotMatchesLineSeparators]
+                ) {
+                    result = regex.stringByReplacingMatches(
+                        in: result,
+                        range: NSRange(result.startIndex..., in: result),
+                        withTemplate: ""
+                    )
+                }
+            }
+        }
+
+        return result
+    }
+
+    /// Removes dangerous attributes from all tags.
+    private func removeDangerousAttributes(_ html: String) -> String {
+        var result = html
+
+        for pattern in Self.dangerousAttributePatterns {
+            // Match attribute="value" or attribute='value' or attribute=value
+            let attrPattern = "\\s+\(pattern)\\s*=\\s*(?:\"[^\"]*\"|'[^']*'|[^\\s>]+)"
+
+            if let regex = try? NSRegularExpression(
+                pattern: attrPattern,
+                options: .caseInsensitive
+            ) {
+                result = regex.stringByReplacingMatches(
+                    in: result,
+                    range: NSRange(result.startIndex..., in: result),
+                    withTemplate: ""
+                )
+            }
+        }
+
+        // Also remove javascript: URLs from href attributes
+        if let jsRegex = try? NSRegularExpression(
+            pattern: "href\\s*=\\s*[\"']?javascript:[^\"'\\s>]*[\"']?",
+            options: .caseInsensitive
+        ) {
+            result = jsRegex.stringByReplacingMatches(
+                in: result,
+                range: NSRange(result.startIndex..., in: result),
+                withTemplate: ""
+            )
+        }
+
+        return result
+    }
+
+    /// Removes tags not in the allow-list, preserving their content.
+    private func removeDisallowedTags(_ html: String) -> String {
+        var result = html
+
+        guard let regex = try? NSRegularExpression(
+            pattern: "</?([a-zA-Z][a-zA-Z0-9]*)(?:\\s[^>]*)?\\/?>",
+            options: []
+        ) else {
+            return html
+        }
+
+        // Find all tags and filter out disallowed ones
+        let matches = regex.matches(
+            in: result,
+            range: NSRange(result.startIndex..., in: result)
+        )
+
+        // Process matches in reverse order to preserve indices
+        for match in matches.reversed() {
+            guard let tagRange = Range(match.range(at: 1), in: result) else {
+                continue
+            }
+
+            let tagName = String(result[tagRange]).lowercased()
+
+            if !Self.allowedTags.contains(tagName) {
+                // Remove the disallowed tag, keeping content
+                if let fullRange = Range(match.range, in: result) {
+                    result.replaceSubrange(fullRange, with: "")
+                }
+            }
+        }
+
+        return result
+    }
+}

--- a/RSSReader/Utilities/HTMLAttributedStringConverter.swift
+++ b/RSSReader/Utilities/HTMLAttributedStringConverter.swift
@@ -96,45 +96,29 @@ struct HTMLAttributedStringConverter {
         <html>
         <head>
         <meta charset="UTF-8">
-        <style>
-            body {
-                font-family: -apple-system, BlinkMacSystemFont, sans-serif;
-                font-size: \(Self.baseFontSize)px;
-                line-height: 1.5;
-            }
-            p { margin-bottom: \(Self.paragraphSpacing)px; }
-            h1, h2, h3, h4, h5, h6 {
-                font-weight: bold;
-                margin-top: \(Self.headingSpacing * 1.5)px;
-                margin-bottom: \(Self.headingSpacing / 2)px;
-            }
-            h1 { font-size: \(Self.headingFontSizes[1] ?? 32)px; }
-            h2 { font-size: \(Self.headingFontSizes[2] ?? 24)px; }
-            h3 { font-size: \(Self.headingFontSizes[3] ?? 20)px; }
-            h4, h5, h6 { font-size: \(Self.headingFontSizes[4] ?? 18)px; }
-            blockquote {
-                margin-left: \(Self.blockquoteIndent)px;
-                padding-left: 10px;
-                border-left: 3px solid #ccc;
-            }
-            pre, code {
-                font-family: Menlo, Monaco, monospace;
-                font-size: \(Self.baseFontSize - 1)px;
-            }
-            pre {
-                padding: 10px;
-                border-radius: 4px;
-                overflow-x: auto;
-            }
-            ul, ol {
-                margin-top: \(Self.listSpacing)px;
-                margin-bottom: \(Self.listSpacing * 2)px;
-            }
-            li { margin-bottom: \(Self.listItemSpacing)px; }
-        </style>
+        <style>\(Self.cssStyles)</style>
         </head>
         <body>\(html)</body>
         </html>
+        """
+    }
+
+    /// CSS styles for the HTML document.
+    private static var cssStyles: String {
+        """
+        body { font-family: -apple-system, sans-serif; font-size: \(baseFontSize)px; line-height: 1.5; }
+        p { margin-bottom: \(paragraphSpacing)px; }
+        h1, h2, h3, h4, h5, h6 { font-weight: bold; margin-top: \(headingSpacing * 1.5)px; \
+        margin-bottom: \(headingSpacing / 2)px; }
+        h1 { font-size: \(headingFontSizes[1] ?? 32)px; }
+        h2 { font-size: \(headingFontSizes[2] ?? 24)px; }
+        h3 { font-size: \(headingFontSizes[3] ?? 20)px; }
+        h4, h5, h6 { font-size: \(headingFontSizes[4] ?? 18)px; }
+        blockquote { margin-left: \(blockquoteIndent)px; padding-left: 10px; border-left: 3px solid #ccc; }
+        pre, code { font-family: Menlo, Monaco, monospace; font-size: \(baseFontSize - 1)px; }
+        pre { padding: 10px; border-radius: 4px; overflow-x: auto; }
+        ul, ol { margin-top: \(listSpacing)px; margin-bottom: \(listSpacing * 2)px; }
+        li { margin-bottom: \(listItemSpacing)px; }
         """
     }
 

--- a/RSSReader/Utilities/HTMLAttributedStringConverter.swift
+++ b/RSSReader/Utilities/HTMLAttributedStringConverter.swift
@@ -80,8 +80,9 @@ struct HTMLAttributedStringConverter {
         // Post-process the attributed string
         applyCustomStyling(to: attributedString)
 
-        // Trim leading whitespace
+        // Normalize whitespace: trim then add leading newline for spacing after header
         trimLeadingWhitespace(from: attributedString)
+        addLeadingNewline(to: attributedString)
 
         return attributedString
     }
@@ -104,7 +105,7 @@ struct HTMLAttributedStringConverter {
             p { margin-bottom: \(Self.paragraphSpacing)px; }
             h1, h2, h3, h4, h5, h6 {
                 font-weight: bold;
-                margin-top: \(Self.headingSpacing)px;
+                margin-top: \(Self.headingSpacing * 1.5)px;
                 margin-bottom: \(Self.headingSpacing / 2)px;
             }
             h1 { font-size: \(Self.headingFontSizes[1] ?? 32)px; }
@@ -127,7 +128,7 @@ struct HTMLAttributedStringConverter {
             }
             ul, ol {
                 margin-top: \(Self.listSpacing)px;
-                margin-bottom: \(Self.listSpacing)px;
+                margin-bottom: \(Self.listSpacing * 2)px;
             }
             li { margin-bottom: \(Self.listItemSpacing)px; }
         </style>
@@ -221,6 +222,20 @@ struct HTMLAttributedStringConverter {
                 in: NSRange(location: 0, length: trimLength)
             )
         }
+    }
+
+    /// Adds a leading newline for spacing after the article header.
+    private func addLeadingNewline(to attributedString: NSMutableAttributedString) {
+        guard attributedString.length > 0 else { return }
+
+        let newline = NSAttributedString(
+            string: "\n",
+            attributes: [
+                .font: NSFont.systemFont(ofSize: Self.baseFontSize),
+                .foregroundColor: NSColor.textColor
+            ]
+        )
+        attributedString.insert(newline, at: 0)
     }
 }
 

--- a/RSSReader/Utilities/HTMLAttributedStringConverter.swift
+++ b/RSSReader/Utilities/HTMLAttributedStringConverter.swift
@@ -1,0 +1,248 @@
+//
+//  HTMLAttributedStringConverter.swift
+//  RSSReader
+//
+//  Created on 2026-02-10.
+//
+
+import AppKit
+import Foundation
+
+/// Converts sanitized HTML to NSAttributedString with rich text formatting.
+///
+/// Applies custom styling for paragraphs, headings, lists, blockquotes,
+/// and code blocks. Uses semantic colors for dark mode support.
+struct HTMLAttributedStringConverter {
+    // MARK: - Style Constants
+
+    /// Base font size for body text (matches reader mode).
+    static let baseFontSize: CGFloat = 16
+
+    /// Paragraph spacing after each paragraph.
+    static let paragraphSpacing: CGFloat = 12
+
+    /// Spacing after headings.
+    static let headingSpacing: CGFloat = 16
+
+    /// Spacing between list items.
+    static let listItemSpacing: CGFloat = 4
+
+    /// Spacing before and after lists.
+    static let listSpacing: CGFloat = 8
+
+    /// Left indent for blockquotes.
+    static let blockquoteIndent: CGFloat = 20
+
+    /// Font sizes for headings.
+    static let headingFontSizes: [Int: CGFloat] = [
+        1: 32,
+        2: 24,
+        3: 20,
+        4: 18,
+        5: 18,
+        6: 18
+    ]
+
+    // MARK: - Public API
+
+    /// Converts HTML string to attributed string with formatting.
+    ///
+    /// - Parameter html: Sanitized HTML string to convert.
+    /// - Returns: Formatted NSAttributedString ready for display.
+    func convert(_ html: String) -> NSAttributedString {
+        guard !html.isEmpty else {
+            return NSAttributedString()
+        }
+
+        // Wrap in HTML document with base styling
+        let wrappedHTML = wrapHTML(html)
+
+        guard let data = wrappedHTML.data(using: .utf8),
+              let attributedString = try? NSMutableAttributedString(
+                  data: data,
+                  options: [
+                      .documentType: NSAttributedString.DocumentType.html,
+                      .characterEncoding: String.Encoding.utf8.rawValue
+                  ],
+                  documentAttributes: nil
+              )
+        else {
+            // Fallback to plain text if HTML parsing fails
+            return NSAttributedString(
+                string: html.strippingHTMLTags(),
+                attributes: [
+                    .font: NSFont.systemFont(ofSize: Self.baseFontSize),
+                    .foregroundColor: NSColor.textColor
+                ]
+            )
+        }
+
+        // Post-process the attributed string
+        applyCustomStyling(to: attributedString)
+
+        // Trim leading whitespace
+        trimLeadingWhitespace(from: attributedString)
+
+        return attributedString
+    }
+
+    // MARK: - Private Helpers
+
+    /// Wraps HTML in a document with base styling.
+    private func wrapHTML(_ html: String) -> String {
+        """
+        <!DOCTYPE html>
+        <html>
+        <head>
+        <meta charset="UTF-8">
+        <style>
+            body {
+                font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+                font-size: \(Self.baseFontSize)px;
+                line-height: 1.5;
+            }
+            p { margin-bottom: \(Self.paragraphSpacing)px; }
+            h1, h2, h3, h4, h5, h6 {
+                font-weight: bold;
+                margin-top: \(Self.headingSpacing)px;
+                margin-bottom: \(Self.headingSpacing / 2)px;
+            }
+            h1 { font-size: \(Self.headingFontSizes[1] ?? 32)px; }
+            h2 { font-size: \(Self.headingFontSizes[2] ?? 24)px; }
+            h3 { font-size: \(Self.headingFontSizes[3] ?? 20)px; }
+            h4, h5, h6 { font-size: \(Self.headingFontSizes[4] ?? 18)px; }
+            blockquote {
+                margin-left: \(Self.blockquoteIndent)px;
+                padding-left: 10px;
+                border-left: 3px solid #ccc;
+            }
+            pre, code {
+                font-family: Menlo, Monaco, monospace;
+                font-size: \(Self.baseFontSize - 1)px;
+            }
+            pre {
+                padding: 10px;
+                border-radius: 4px;
+                overflow-x: auto;
+            }
+            ul, ol {
+                margin-top: \(Self.listSpacing)px;
+                margin-bottom: \(Self.listSpacing)px;
+            }
+            li { margin-bottom: \(Self.listItemSpacing)px; }
+        </style>
+        </head>
+        <body>\(html)</body>
+        </html>
+        """
+    }
+
+    /// Applies custom styling post-processing to the attributed string.
+    private func applyCustomStyling(to attributedString: NSMutableAttributedString) {
+        let fullRange = NSRange(location: 0, length: attributedString.length)
+
+        // Apply text color for dark mode support
+        attributedString.addAttribute(
+            .foregroundColor,
+            value: NSColor.textColor,
+            range: fullRange
+        )
+
+        // Process code blocks for background color
+        applyCodeBlockStyling(to: attributedString)
+
+        // Ensure links are styled appropriately
+        applyLinkStyling(to: attributedString)
+    }
+
+    /// Applies styling to code blocks.
+    private func applyCodeBlockStyling(to attributedString: NSMutableAttributedString) {
+        let fullRange = NSRange(location: 0, length: attributedString.length)
+
+        attributedString.enumerateAttribute(
+            .font,
+            in: fullRange,
+            options: []
+        ) { value, range, _ in
+            guard let font = value as? NSFont else { return }
+
+            // Detect monospace fonts (code blocks)
+            if font.fontName.lowercased().contains("menlo") ||
+               font.fontName.lowercased().contains("monaco") ||
+               font.fontName.lowercased().contains("courier") ||
+               font.isFixedPitch {
+                // Apply subtle background for code
+                let bgColor = NSColor.textBackgroundColor.blended(
+                    withFraction: 0.05,
+                    of: NSColor.labelColor
+                ) ?? NSColor.textBackgroundColor
+
+                attributedString.addAttribute(
+                    .backgroundColor,
+                    value: bgColor,
+                    range: range
+                )
+            }
+        }
+    }
+
+    /// Applies styling to links.
+    private func applyLinkStyling(to attributedString: NSMutableAttributedString) {
+        let fullRange = NSRange(location: 0, length: attributedString.length)
+
+        attributedString.enumerateAttribute(
+            .link,
+            in: fullRange,
+            options: []
+        ) { value, range, _ in
+            guard value != nil else { return }
+
+            attributedString.addAttributes([
+                .foregroundColor: NSColor.linkColor,
+                .underlineStyle: NSUnderlineStyle.single.rawValue
+            ], range: range)
+        }
+    }
+
+    /// Trims leading whitespace from the attributed string.
+    private func trimLeadingWhitespace(from attributedString: NSMutableAttributedString) {
+        let string = attributedString.string
+        var startIndex = string.startIndex
+
+        // Find first non-whitespace character
+        while startIndex < string.endIndex,
+              string[startIndex].isWhitespace || string[startIndex].isNewline {
+            startIndex = string.index(after: startIndex)
+        }
+
+        if startIndex > string.startIndex {
+            let trimLength = string.distance(from: string.startIndex, to: startIndex)
+            attributedString.deleteCharacters(
+                in: NSRange(location: 0, length: trimLength)
+            )
+        }
+    }
+}
+
+// MARK: - String Extension
+
+private extension String {
+    /// Simple HTML tag stripping for fallback.
+    func strippingHTMLTags() -> String {
+        self.replacingOccurrences(
+            of: "<[^>]+>",
+            with: "",
+            options: .regularExpression
+        )
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+// MARK: - NSFont Extension
+
+private extension NSFont {
+    /// Checks if the font is fixed-pitch (monospace).
+    var isFixedPitch: Bool {
+        fontDescriptor.symbolicTraits.contains(.monoSpace)
+    }
+}

--- a/RSSReader/ViewModels/ArticleDetailViewModel.swift
+++ b/RSSReader/ViewModels/ArticleDetailViewModel.swift
@@ -59,6 +59,26 @@ final class ArticleDetailViewModel: ObservableObject {
         return raw.htmlToFormattedText()
     }
 
+    /// Returns the article body as rich text NSAttributedString.
+    ///
+    /// Sanitizes HTML content for security and converts to
+    /// NSAttributedString with formatting. Prefers `content` over `summary`.
+    func attributedContent(
+        for article: CDArticle
+    ) -> NSAttributedString {
+        let raw = article.content
+            ?? article.summary
+            ?? ""
+
+        // Sanitize HTML to remove dangerous elements
+        let sanitizer = HTMLSanitizer()
+        let safeHTML = sanitizer.sanitize(raw)
+
+        // Convert to attributed string with formatting
+        let converter = HTMLAttributedStringConverter()
+        return converter.convert(safeHTML)
+    }
+
     // MARK: - Actions
 
     /// Marks the article as read in Core Data if it is

--- a/RSSReader/Views/ArticleDetail/ArticleDetailView.swift
+++ b/RSSReader/Views/ArticleDetail/ArticleDetailView.swift
@@ -10,7 +10,7 @@ import CoreData
 import SwiftUI
 
 /// Reading pane displaying the selected article's title,
-/// metadata, and plain-text content.
+/// metadata, and rich text content.
 ///
 /// Clicking the article title opens it in Safari.
 /// Automatically marks the article as read when displayed.
@@ -201,26 +201,20 @@ struct ArticleDetailView: View {
 
     // MARK: - Body Text
 
-    /// Reader-mode style body font (slightly larger than system body)
-    private static let readerFont = Font.system(size: 16)
-
     private func bodyText(
         _ article: CDArticle
     ) -> some View {
-        let text = viewModel.formattedContent(
+        let attributedString = viewModel.attributedContent(
             for: article
         )
 
         return Group {
-            if text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            if attributedString.length == 0 {
                 Text("No content available.")
                     .foregroundStyle(.tertiary)
                     .italic()
             } else {
-                Text(text)
-                    .font(Self.readerFont)
-                    .lineSpacing(8)
-                    .textSelection(.enabled)
+                RichTextView(attributedString: attributedString)
                     .frame(maxWidth: 700, alignment: .leading)
             }
         }

--- a/RSSReader/Views/ArticleDetail/ArticleDetailView.swift
+++ b/RSSReader/Views/ArticleDetail/ArticleDetailView.swift
@@ -201,6 +201,9 @@ struct ArticleDetailView: View {
 
     // MARK: - Body Text
 
+    /// Maximum width for article content for comfortable reading.
+    private static let maxContentWidth: CGFloat = 700
+
     private func bodyText(
         _ article: CDArticle
     ) -> some View {
@@ -214,8 +217,11 @@ struct ArticleDetailView: View {
                     .foregroundStyle(.tertiary)
                     .italic()
             } else {
-                RichTextView(attributedString: attributedString)
-                    .frame(maxWidth: 700, alignment: .leading)
+                RichTextView(
+                    attributedString: attributedString,
+                    containerWidth: Self.maxContentWidth
+                )
+                .frame(maxWidth: Self.maxContentWidth, alignment: .leading)
             }
         }
     }

--- a/RSSReader/Views/ArticleDetail/ArticleDetailView.swift
+++ b/RSSReader/Views/ArticleDetail/ArticleDetailView.swift
@@ -201,9 +201,6 @@ struct ArticleDetailView: View {
 
     // MARK: - Body Text
 
-    /// Maximum width for article content for comfortable reading.
-    private static let maxContentWidth: CGFloat = 700
-
     private func bodyText(
         _ article: CDArticle
     ) -> some View {
@@ -219,9 +216,9 @@ struct ArticleDetailView: View {
             } else {
                 RichTextView(
                     attributedString: attributedString,
-                    containerWidth: Self.maxContentWidth
+                    containerWidth: 1000  // Fallback, actual width from SwiftUI proposal
                 )
-                .frame(maxWidth: Self.maxContentWidth, alignment: .leading)
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
     }

--- a/RSSReader/Views/ArticleDetail/RichTextView.swift
+++ b/RSSReader/Views/ArticleDetail/RichTextView.swift
@@ -12,18 +12,18 @@ import SwiftUI
 ///
 /// Provides a non-editable, selectable text view with link detection
 /// and proper dark mode support for rendering NSAttributedString content.
+/// Calculates its own height based on content for proper SwiftUI layout.
 struct RichTextView: NSViewRepresentable {
     /// The attributed string to display.
     let attributedString: NSAttributedString
 
+    /// The width to use for calculating text height.
+    let containerWidth: CGFloat
+
     // MARK: - NSViewRepresentable
 
-    func makeNSView(context: Context) -> NSScrollView {
-        let scrollView = NSTextView.scrollableTextView()
-
-        guard let textView = scrollView.documentView as? NSTextView else {
-            return scrollView
-        }
+    func makeNSView(context: Context) -> NSTextView {
+        let textView = NSTextView()
 
         // Configure for reading
         textView.isEditable = false
@@ -32,6 +32,16 @@ struct RichTextView: NSViewRepresentable {
 
         // Remove text container insets for cleaner layout
         textView.textContainerInset = NSSize(width: 0, height: 0)
+
+        // Configure text container for proper wrapping
+        textView.textContainer?.lineFragmentPadding = 0
+        textView.textContainer?.widthTracksTextView = true
+        textView.textContainer?.heightTracksTextView = false
+
+        // Allow vertical resizing
+        textView.isVerticallyResizable = true
+        textView.isHorizontallyResizable = false
+        textView.autoresizingMask = [.width]
 
         // Reader-friendly settings
         textView.isAutomaticLinkDetectionEnabled = true
@@ -52,30 +62,45 @@ struct RichTextView: NSViewRepresentable {
         textView.setAccessibilityLabel("Article content")
         textView.setAccessibilityRole(.textArea)
 
-        // Configure scroll view
-        scrollView.hasVerticalScroller = false
-        scrollView.hasHorizontalScroller = false
-        scrollView.drawsBackground = false
-        scrollView.autohidesScrollers = true
-
         // Set initial content
         textView.textStorage?.setAttributedString(attributedString)
 
-        return scrollView
+        return textView
     }
 
-    func updateNSView(_ nsView: NSScrollView, context: Context) {
-        guard let textView = nsView.documentView as? NSTextView else {
-            return
-        }
-
+    func updateNSView(_ textView: NSTextView, context: Context) {
         // Only update if content changed
         if textView.textStorage?.string != attributedString.string {
             textView.textStorage?.setAttributedString(attributedString)
-
-            // Scroll to top when content changes
-            textView.scrollToBeginningOfDocument(nil)
         }
+    }
+
+    func sizeThatFits(
+        _ proposal: ProposedViewSize,
+        nsView textView: NSTextView,
+        context: Context
+    ) -> CGSize? {
+        let width = proposal.width ?? containerWidth
+
+        // Set the text container width
+        textView.textContainer?.containerSize = CGSize(
+            width: width,
+            height: CGFloat.greatestFiniteMagnitude
+        )
+
+        // Force layout
+        textView.layoutManager?.ensureLayout(
+            for: textView.textContainer!  // swiftlint:disable:this force_unwrapping
+        )
+
+        // Get the used rect
+        guard let layoutManager = textView.layoutManager,
+              let textContainer = textView.textContainer else {
+            return CGSize(width: width, height: 100)
+        }
+
+        let usedRect = layoutManager.usedRect(for: textContainer)
+        return CGSize(width: width, height: usedRect.height + 20)
     }
 }
 
@@ -102,8 +127,14 @@ struct RichTextView: NSViewRepresentable {
     let converter = HTMLAttributedStringConverter()
     let attributedString = converter.convert(sampleHTML)
 
-    return RichTextView(attributedString: attributedString)
-        .frame(width: 600, height: 400)
+    return ScrollView {
+        RichTextView(
+            attributedString: attributedString,
+            containerWidth: 600
+        )
+        .frame(width: 600)
         .padding()
+    }
+    .frame(width: 650, height: 400)
 }
 #endif

--- a/RSSReader/Views/ArticleDetail/RichTextView.swift
+++ b/RSSReader/Views/ArticleDetail/RichTextView.swift
@@ -1,0 +1,109 @@
+//
+//  RichTextView.swift
+//  RSSReader
+//
+//  Created on 2026-02-10.
+//
+
+import AppKit
+import SwiftUI
+
+/// SwiftUI wrapper for NSTextView displaying rich text content.
+///
+/// Provides a non-editable, selectable text view with link detection
+/// and proper dark mode support for rendering NSAttributedString content.
+struct RichTextView: NSViewRepresentable {
+    /// The attributed string to display.
+    let attributedString: NSAttributedString
+
+    // MARK: - NSViewRepresentable
+
+    func makeNSView(context: Context) -> NSScrollView {
+        let scrollView = NSTextView.scrollableTextView()
+
+        guard let textView = scrollView.documentView as? NSTextView else {
+            return scrollView
+        }
+
+        // Configure for reading
+        textView.isEditable = false
+        textView.isSelectable = true
+        textView.drawsBackground = false
+
+        // Remove text container insets for cleaner layout
+        textView.textContainerInset = NSSize(width: 0, height: 0)
+
+        // Reader-friendly settings
+        textView.isAutomaticLinkDetectionEnabled = true
+        textView.isAutomaticDataDetectionEnabled = false
+        textView.isAutomaticQuoteSubstitutionEnabled = false
+        textView.isAutomaticDashSubstitutionEnabled = false
+        textView.isAutomaticTextReplacementEnabled = false
+        textView.isAutomaticSpellingCorrectionEnabled = false
+
+        // Link styling
+        textView.linkTextAttributes = [
+            .foregroundColor: NSColor.linkColor,
+            .underlineStyle: NSUnderlineStyle.single.rawValue,
+            .cursor: NSCursor.pointingHand
+        ]
+
+        // Accessibility
+        textView.setAccessibilityLabel("Article content")
+        textView.setAccessibilityRole(.textArea)
+
+        // Configure scroll view
+        scrollView.hasVerticalScroller = false
+        scrollView.hasHorizontalScroller = false
+        scrollView.drawsBackground = false
+        scrollView.autohidesScrollers = true
+
+        // Set initial content
+        textView.textStorage?.setAttributedString(attributedString)
+
+        return scrollView
+    }
+
+    func updateNSView(_ nsView: NSScrollView, context: Context) {
+        guard let textView = nsView.documentView as? NSTextView else {
+            return
+        }
+
+        // Only update if content changed
+        if textView.textStorage?.string != attributedString.string {
+            textView.textStorage?.setAttributedString(attributedString)
+
+            // Scroll to top when content changes
+            textView.scrollToBeginningOfDocument(nil)
+        }
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+#Preview("Rich Text View") {
+    let sampleHTML = """
+    <h1>Welcome to the Article</h1>
+    <p>This is a <strong>bold</strong> and <em>italic</em> text example.</p>
+    <h2>Code Example</h2>
+    <pre><code>let greeting = "Hello, World!"
+    print(greeting)</code></pre>
+    <blockquote>This is a quoted section that should be indented.</blockquote>
+    <h3>A List</h3>
+    <ul>
+        <li>First item</li>
+        <li>Second item</li>
+        <li>Third item</li>
+    </ul>
+    <p>Visit <a href="https://example.com">Example.com</a> for more.</p>
+    """
+
+    let converter = HTMLAttributedStringConverter()
+    let attributedString = converter.convert(sampleHTML)
+
+    return RichTextView(attributedString: attributedString)
+        .frame(width: 600, height: 400)
+        .padding()
+}
+#endif

--- a/RSSReader/Views/Settings/SettingsView.swift
+++ b/RSSReader/Views/Settings/SettingsView.swift
@@ -223,8 +223,9 @@ struct SettingsView: View {
     }
 
     private var appVersion: String {
-        let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.2"
-        let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "1"
+        let info = Bundle.main.infoDictionary
+        let version = info?["CFBundleShortVersionString"] as? String ?? "0.0.2"
+        let build = info?["CFBundleVersion"] as? String ?? "1"
         return "\(version) (\(build))"
     }
 

--- a/RSSReader/Views/Settings/SettingsView.swift
+++ b/RSSReader/Views/Settings/SettingsView.swift
@@ -55,6 +55,11 @@ struct SettingsView: View {
                 .tabItem {
                     Label("Cleanup", systemImage: "trash")
                 }
+
+            aboutTab
+                .tabItem {
+                    Label("About", systemImage: "info.circle")
+                }
         }
         .frame(width: 500, height: 300)
         .onAppear {
@@ -188,6 +193,39 @@ struct SettingsView: View {
             .pickerStyle(.menu)
             .frame(width: 200)
         }
+    }
+
+    // MARK: - About Tab
+
+    private var aboutTab: some View {
+        VStack(spacing: 16) {
+            Spacer()
+
+            Image(nsImage: NSApp.applicationIconImage)
+                .resizable()
+                .frame(width: 80, height: 80)
+
+            Text("Syndicate")
+                .font(.title)
+                .fontWeight(.bold)
+
+            Text("Version \(appVersion)")
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+
+            Text("A native RSS reader for macOS")
+                .font(.caption)
+                .foregroundColor(.secondary)
+
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var appVersion: String {
+        let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.2"
+        let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "1"
+        return "\(version) (\(build))"
     }
 
     // MARK: - Data Management

--- a/RSSReaderTests/UnitTests/Services/HTMLSanitizerTests.swift
+++ b/RSSReaderTests/UnitTests/Services/HTMLSanitizerTests.swift
@@ -1,0 +1,322 @@
+//
+//  HTMLSanitizerTests.swift
+//  RSSReaderTests
+//
+//  Created on 2026-02-10.
+//
+
+import Foundation
+import Testing
+@testable import RSSReader
+
+@Suite("HTMLSanitizer Tests")
+struct HTMLSanitizerTests {
+    private let sut = HTMLSanitizer()
+
+    // MARK: - Dangerous Tag Removal
+
+    @Test("Removes script tags and content")
+    func removesScriptTags() {
+        let input = "<p>Hello</p><script>alert('xss')</script><p>World</p>"
+        let result = sut.sanitize(input)
+        #expect(!result.contains("script"))
+        #expect(!result.contains("alert"))
+        #expect(result.contains("<p>Hello</p>"))
+        #expect(result.contains("<p>World</p>"))
+    }
+
+    @Test("Removes style tags and content")
+    func removesStyleTags() {
+        let input = "<style>.hidden { display: none; }</style><p>Content</p>"
+        let result = sut.sanitize(input)
+        #expect(!result.contains("style"))
+        #expect(!result.contains("hidden"))
+        #expect(result.contains("<p>Content</p>"))
+    }
+
+    @Test("Removes iframe tags")
+    func removesIframeTags() {
+        let input = "<p>Before</p><iframe src=\"evil.com\"></iframe><p>After</p>"
+        let result = sut.sanitize(input)
+        #expect(!result.contains("iframe"))
+        #expect(!result.contains("evil.com"))
+    }
+
+    @Test("Removes object tags")
+    func removesObjectTags() {
+        let input = "<object data=\"flash.swf\"></object><p>Text</p>"
+        let result = sut.sanitize(input)
+        #expect(!result.contains("object"))
+        #expect(!result.contains("flash"))
+    }
+
+    @Test("Removes embed tags")
+    func removesEmbedTags() {
+        let input = "<embed src=\"plugin.swf\"><p>Text</p>"
+        let result = sut.sanitize(input)
+        #expect(!result.contains("embed"))
+        #expect(!result.contains("plugin"))
+    }
+
+    @Test("Removes form elements")
+    func removesFormElements() {
+        let input = "<form action=\"/steal\"><input type=\"text\"><button>Submit</button></form>"
+        let result = sut.sanitize(input)
+        #expect(!result.contains("form"))
+        #expect(!result.contains("input"))
+        #expect(!result.contains("button"))
+    }
+
+    // MARK: - Dangerous Attribute Removal
+
+    @Test("Removes onclick attributes")
+    func removesOnclickAttributes() {
+        let input = "<p onclick=\"evil()\">Click me</p>"
+        let result = sut.sanitize(input)
+        #expect(!result.contains("onclick"))
+        #expect(!result.contains("evil"))
+        #expect(result.contains("<p>Click me</p>"))
+    }
+
+    @Test("Removes onload attributes")
+    func removesOnloadAttributes() {
+        let input = "<p onload=\"steal()\">Content</p>"
+        let result = sut.sanitize(input)
+        #expect(!result.contains("onload"))
+    }
+
+    @Test("Removes onerror attributes")
+    func removesOnerrorAttributes() {
+        let input = "<img onerror=\"hack()\">"
+        let result = sut.sanitize(input)
+        #expect(!result.contains("onerror"))
+    }
+
+    @Test("Removes onmouseover attributes")
+    func removesOnmouseoverAttributes() {
+        let input = "<p onmouseover=\"track()\">Hover</p>"
+        let result = sut.sanitize(input)
+        #expect(!result.contains("onmouseover"))
+    }
+
+    @Test("Removes style attributes")
+    func removesStyleAttributes() {
+        let input = "<p style=\"color: red;\">Styled</p>"
+        let result = sut.sanitize(input)
+        #expect(!result.contains("style="))
+        #expect(!result.contains("color"))
+    }
+
+    @Test("Removes class attributes")
+    func removesClassAttributes() {
+        let input = "<p class=\"highlight\">Classed</p>"
+        let result = sut.sanitize(input)
+        #expect(!result.contains("class="))
+        #expect(!result.contains("highlight"))
+    }
+
+    @Test("Removes id attributes")
+    func removesIdAttributes() {
+        let input = "<p id=\"unique\">Identified</p>"
+        let result = sut.sanitize(input)
+        #expect(!result.contains("id="))
+    }
+
+    @Test("Removes javascript URLs from href")
+    func removesJavascriptURLs() {
+        let input = "<a href=\"javascript:alert('xss')\">Click</a>"
+        let result = sut.sanitize(input)
+        #expect(!result.contains("javascript:"))
+    }
+
+    // MARK: - Allowed Tag Preservation
+
+    @Test("Preserves paragraph tags")
+    func preservesParagraphTags() {
+        let input = "<p>Paragraph content</p>"
+        let result = sut.sanitize(input)
+        #expect(result.contains("<p>"))
+        #expect(result.contains("</p>"))
+        #expect(result.contains("Paragraph content"))
+    }
+
+    @Test("Preserves bold tags")
+    func preservesBoldTags() {
+        let input = "<b>Bold text</b>"
+        let result = sut.sanitize(input)
+        #expect(result.contains("<b>Bold text</b>"))
+    }
+
+    @Test("Preserves strong tags")
+    func preservesStrongTags() {
+        let input = "<strong>Strong text</strong>"
+        let result = sut.sanitize(input)
+        #expect(result.contains("<strong>Strong text</strong>"))
+    }
+
+    @Test("Preserves italic tags")
+    func preservesItalicTags() {
+        let input = "<i>Italic text</i>"
+        let result = sut.sanitize(input)
+        #expect(result.contains("<i>Italic text</i>"))
+    }
+
+    @Test("Preserves em tags")
+    func preservesEmTags() {
+        let input = "<em>Emphasized text</em>"
+        let result = sut.sanitize(input)
+        #expect(result.contains("<em>Emphasized text</em>"))
+    }
+
+    @Test("Preserves blockquote tags")
+    func preservesBlockquoteTags() {
+        let input = "<blockquote>Quoted text</blockquote>"
+        let result = sut.sanitize(input)
+        #expect(result.contains("<blockquote>Quoted text</blockquote>"))
+    }
+
+    @Test("Preserves heading tags")
+    func preservesHeadingTags() {
+        let input = "<h1>Title</h1><h2>Subtitle</h2><h3>Section</h3>"
+        let result = sut.sanitize(input)
+        #expect(result.contains("<h1>Title</h1>"))
+        #expect(result.contains("<h2>Subtitle</h2>"))
+        #expect(result.contains("<h3>Section</h3>"))
+    }
+
+    @Test("Preserves code and pre tags")
+    func preservesCodeTags() {
+        let input = "<pre><code>let x = 1</code></pre>"
+        let result = sut.sanitize(input)
+        #expect(result.contains("<pre>"))
+        #expect(result.contains("<code>"))
+        #expect(result.contains("let x = 1"))
+    }
+
+    @Test("Preserves list tags")
+    func preservesListTags() {
+        let input = "<ul><li>Item 1</li><li>Item 2</li></ul>"
+        let result = sut.sanitize(input)
+        #expect(result.contains("<ul>"))
+        #expect(result.contains("<li>"))
+        #expect(result.contains("</ul>"))
+    }
+
+    @Test("Preserves ordered list tags")
+    func preservesOrderedListTags() {
+        let input = "<ol><li>First</li><li>Second</li></ol>"
+        let result = sut.sanitize(input)
+        #expect(result.contains("<ol>"))
+        #expect(result.contains("<li>"))
+        #expect(result.contains("</ol>"))
+    }
+
+    @Test("Preserves br tags")
+    func preservesBrTags() {
+        let input = "Line 1<br>Line 2<br/>Line 3"
+        let result = sut.sanitize(input)
+        #expect(result.contains("<br>") || result.contains("<br/>"))
+    }
+
+    @Test("Preserves anchor tags with safe href")
+    func preservesAnchorTags() {
+        let input = "<a href=\"https://example.com\">Link</a>"
+        let result = sut.sanitize(input)
+        #expect(result.contains("<a"))
+        #expect(result.contains("href=\"https://example.com\""))
+    }
+
+    // MARK: - Disallowed Tag Removal (Content Preserved)
+
+    @Test("Removes div tags but preserves content")
+    func removesDivPreservesContent() {
+        let input = "<div>Content inside div</div>"
+        let result = sut.sanitize(input)
+        #expect(!result.contains("<div"))
+        #expect(!result.contains("</div>"))
+        #expect(result.contains("Content inside div"))
+    }
+
+    @Test("Removes span tags but preserves content")
+    func removesSpanPreservesContent() {
+        let input = "<span>Span content</span>"
+        let result = sut.sanitize(input)
+        #expect(!result.contains("<span"))
+        #expect(!result.contains("</span>"))
+        #expect(result.contains("Span content"))
+    }
+
+    @Test("Removes img tags")
+    func removesImgTags() {
+        let input = "<p>Text</p><img src=\"image.jpg\" alt=\"Image\"><p>More</p>"
+        let result = sut.sanitize(input)
+        #expect(!result.contains("<img"))
+    }
+
+    // MARK: - Edge Cases
+
+    @Test("Handles empty input")
+    func handlesEmptyInput() {
+        let result = sut.sanitize("")
+        #expect(result.isEmpty)
+    }
+
+    @Test("Handles plain text without HTML")
+    func handlesPlainText() {
+        let input = "Just some plain text"
+        let result = sut.sanitize(input)
+        #expect(result == "Just some plain text")
+    }
+
+    @Test("Handles nested allowed tags")
+    func handlesNestedAllowedTags() {
+        let input = "<p><strong>Bold <em>and italic</em></strong></p>"
+        let result = sut.sanitize(input)
+        #expect(result.contains("<p>"))
+        #expect(result.contains("<strong>"))
+        #expect(result.contains("<em>"))
+    }
+
+    @Test("Handles case-insensitive tags")
+    func handlesCaseInsensitiveTags() {
+        let input = "<SCRIPT>alert('xss')</SCRIPT><P>Content</P>"
+        let result = sut.sanitize(input)
+        #expect(!result.lowercased().contains("script"))
+        #expect(result.contains("Content"))
+    }
+
+    @Test("Handles malformed HTML gracefully")
+    func handlesMalformedHTML() {
+        let input = "<p>Unclosed paragraph<script>evil()</script>"
+        let result = sut.sanitize(input)
+        #expect(!result.contains("script"))
+        #expect(result.contains("Unclosed paragraph"))
+    }
+
+    @Test("Strips dangerous attributes from allowed tags")
+    func stripsDangerousFromAllowed() {
+        let input = "<p onclick=\"hack()\" style=\"color:red\">Safe content</p>"
+        let result = sut.sanitize(input)
+        #expect(!result.contains("onclick"))
+        #expect(!result.contains("style"))
+        #expect(result.contains("<p>Safe content</p>"))
+    }
+
+    @Test("Handles multiline script content")
+    func handlesMultilineScript() {
+        let input = """
+        <p>Before</p>
+        <script>
+        function evil() {
+            steal();
+        }
+        </script>
+        <p>After</p>
+        """
+        let result = sut.sanitize(input)
+        #expect(!result.contains("script"))
+        #expect(!result.contains("function"))
+        #expect(result.contains("<p>Before</p>"))
+        #expect(result.contains("<p>After</p>"))
+    }
+}

--- a/RSSReaderTests/UnitTests/Utilities/HTMLAttributedStringConverterTests.swift
+++ b/RSSReaderTests/UnitTests/Utilities/HTMLAttributedStringConverterTests.swift
@@ -1,0 +1,376 @@
+//
+//  HTMLAttributedStringConverterTests.swift
+//  RSSReaderTests
+//
+//  Created on 2026-02-10.
+//
+
+import AppKit
+import Foundation
+import Testing
+@testable import RSSReader
+
+@Suite("HTMLAttributedStringConverter Tests")
+struct HTMLAttributedStringConverterTests {
+    private let sut = HTMLAttributedStringConverter()
+
+    // MARK: - Basic Conversion
+
+    @Test("Converts plain text correctly")
+    func convertsPlainText() {
+        let html = "Hello, World!"
+        let result = sut.convert(html)
+        #expect(result.string.contains("Hello, World!"))
+    }
+
+    @Test("Returns empty attributed string for empty input")
+    func handlesEmptyInput() {
+        let result = sut.convert("")
+        #expect(result.length == 0)
+    }
+
+    @Test("Preserves paragraph content")
+    func preservesParagraphContent() {
+        let html = "<p>First paragraph</p><p>Second paragraph</p>"
+        let result = sut.convert(html)
+        #expect(result.string.contains("First paragraph"))
+        #expect(result.string.contains("Second paragraph"))
+    }
+
+    // MARK: - Bold Formatting
+
+    @Test("Applies bold formatting to strong tags")
+    func appliesBoldToStrong() {
+        let html = "<p><strong>Bold text</strong></p>"
+        let result = sut.convert(html)
+
+        let hasBold = containsBoldFont(in: result)
+        #expect(hasBold, "Expected bold font for <strong> tag")
+    }
+
+    @Test("Applies bold formatting to b tags")
+    func appliesBoldToB() {
+        let html = "<p><b>Bold text</b></p>"
+        let result = sut.convert(html)
+
+        let hasBold = containsBoldFont(in: result)
+        #expect(hasBold, "Expected bold font for <b> tag")
+    }
+
+    // MARK: - Italic Formatting
+
+    @Test("Applies italic formatting to em tags")
+    func appliesItalicToEm() {
+        let html = "<p><em>Italic text</em></p>"
+        let result = sut.convert(html)
+
+        let hasItalic = containsItalicFont(in: result)
+        #expect(hasItalic, "Expected italic font for <em> tag")
+    }
+
+    @Test("Applies italic formatting to i tags")
+    func appliesItalicToI() {
+        let html = "<p><i>Italic text</i></p>"
+        let result = sut.convert(html)
+
+        let hasItalic = containsItalicFont(in: result)
+        #expect(hasItalic, "Expected italic font for <i> tag")
+    }
+
+    // MARK: - Heading Formatting
+
+    @Test("Applies larger font to h1 tags")
+    func appliesLargerFontToH1() {
+        let html = "<h1>Heading 1</h1><p>Body text</p>"
+        let result = sut.convert(html)
+
+        let maxFontSize = findMaxFontSize(in: result)
+        #expect(maxFontSize >= 30, "Expected h1 to have font size >= 30pt")
+    }
+
+    @Test("Applies correct font size hierarchy to headings")
+    func appliesHeadingHierarchy() {
+        let html = "<h1>H1</h1><h2>H2</h2><h3>H3</h3>"
+        let result = sut.convert(html)
+
+        let fontSizes = findAllFontSizes(in: result)
+        // h1 should be larger than h2, h2 larger than h3
+        #expect(fontSizes.count >= 3, "Expected at least 3 different font sizes")
+    }
+
+    @Test("Applies bold to heading tags")
+    func appliesBoldToHeadings() {
+        let html = "<h2>Heading 2</h2>"
+        let result = sut.convert(html)
+
+        let hasBold = containsBoldFont(in: result)
+        #expect(hasBold, "Expected bold font for heading")
+    }
+
+    // MARK: - Code Formatting
+
+    @Test("Applies monospace font to code tags")
+    func appliesMonospaceToCode() {
+        let html = "<p>Use <code>let x = 1</code> to declare</p>"
+        let result = sut.convert(html)
+
+        let hasMonospace = containsMonospaceFont(in: result)
+        #expect(hasMonospace, "Expected monospace font for <code> tag")
+    }
+
+    @Test("Applies monospace font to pre tags")
+    func appliesMonospaceToPre() {
+        let html = "<pre>function test() { return 42; }</pre>"
+        let result = sut.convert(html)
+
+        let hasMonospace = containsMonospaceFont(in: result)
+        #expect(hasMonospace, "Expected monospace font for <pre> tag")
+    }
+
+    @Test("Applies background to code blocks")
+    func appliesBackgroundToCode() {
+        let html = "<pre><code>let x = 1</code></pre>"
+        let result = sut.convert(html)
+
+        let hasBackground = containsBackgroundColor(in: result)
+        #expect(hasBackground, "Expected background color for code block")
+    }
+
+    // MARK: - List Formatting
+
+    @Test("Preserves unordered list content")
+    func preservesUnorderedListContent() {
+        let html = "<ul><li>Item 1</li><li>Item 2</li></ul>"
+        let result = sut.convert(html)
+        #expect(result.string.contains("Item 1"))
+        #expect(result.string.contains("Item 2"))
+    }
+
+    @Test("Preserves ordered list content")
+    func preservesOrderedListContent() {
+        let html = "<ol><li>First</li><li>Second</li></ol>"
+        let result = sut.convert(html)
+        #expect(result.string.contains("First"))
+        #expect(result.string.contains("Second"))
+    }
+
+    // MARK: - Blockquote Formatting
+
+    @Test("Preserves blockquote content")
+    func preservesBlockquoteContent() {
+        let html = "<blockquote>Quoted text here</blockquote>"
+        let result = sut.convert(html)
+        #expect(result.string.contains("Quoted text here"))
+    }
+
+    // MARK: - Link Formatting
+
+    @Test("Preserves link content")
+    func preservesLinkContent() {
+        let html = "<p>Visit <a href=\"https://example.com\">Example</a></p>"
+        let result = sut.convert(html)
+        #expect(result.string.contains("Example"))
+    }
+
+    @Test("Applies link styling")
+    func appliesLinkStyling() {
+        let html = "<p><a href=\"https://example.com\">Link</a></p>"
+        let result = sut.convert(html)
+
+        let hasLink = containsLinkAttribute(in: result)
+        #expect(hasLink, "Expected link attribute")
+    }
+
+    // MARK: - Whitespace Handling
+
+    @Test("Trims leading whitespace")
+    func trimsLeadingWhitespace() {
+        let html = "   \n  <p>Content starts here</p>"
+        let result = sut.convert(html)
+
+        let string = result.string
+        #expect(!string.hasPrefix(" "), "Expected leading spaces to be trimmed")
+        #expect(!string.hasPrefix("\n"), "Expected leading newlines to be trimmed")
+    }
+
+    @Test("Trims leading whitespace from content")
+    func trimsLeadingWhitespaceFromContent() {
+        let html = "\n\n   First line of content"
+        let result = sut.convert(html)
+
+        let string = result.string
+        #expect(
+            string.first?.isWhitespace == false,
+            "Expected first character to not be whitespace"
+        )
+    }
+
+    // MARK: - Nested Formatting
+
+    @Test("Handles nested bold inside italic")
+    func handlesNestedBoldInsideItalic() {
+        let html = "<p><em>Italic <strong>bold italic</strong></em></p>"
+        let result = sut.convert(html)
+
+        #expect(result.string.contains("bold italic"))
+        #expect(containsBoldFont(in: result))
+        #expect(containsItalicFont(in: result))
+    }
+
+    @Test("Handles deeply nested content")
+    func handlesDeeplyNestedContent() {
+        let html = """
+        <blockquote>
+            <p>Quote with <strong>bold</strong> and <em>italic</em></p>
+        </blockquote>
+        """
+        let result = sut.convert(html)
+
+        #expect(result.string.contains("Quote with"))
+        #expect(result.string.contains("bold"))
+        #expect(result.string.contains("italic"))
+    }
+
+    // MARK: - Text Color
+
+    @Test("Applies text color attribute")
+    func appliesTextColor() {
+        let html = "<p>Text content</p>"
+        let result = sut.convert(html)
+
+        let hasTextColor = containsForegroundColor(in: result)
+        #expect(hasTextColor, "Expected foreground color attribute")
+    }
+
+    // MARK: - Test Helpers
+
+    private func containsBoldFont(in attributedString: NSAttributedString) -> Bool {
+        var found = false
+        attributedString.enumerateAttribute(
+            .font,
+            in: NSRange(location: 0, length: attributedString.length),
+            options: []
+        ) { value, _, stop in
+            if let font = value as? NSFont {
+                let traits = font.fontDescriptor.symbolicTraits
+                if traits.contains(.bold) {
+                    found = true
+                    stop.pointee = true
+                }
+            }
+        }
+        return found
+    }
+
+    private func containsItalicFont(in attributedString: NSAttributedString) -> Bool {
+        var found = false
+        attributedString.enumerateAttribute(
+            .font,
+            in: NSRange(location: 0, length: attributedString.length),
+            options: []
+        ) { value, _, stop in
+            if let font = value as? NSFont {
+                let traits = font.fontDescriptor.symbolicTraits
+                if traits.contains(.italic) {
+                    found = true
+                    stop.pointee = true
+                }
+            }
+        }
+        return found
+    }
+
+    private func containsMonospaceFont(in attributedString: NSAttributedString) -> Bool {
+        var found = false
+        attributedString.enumerateAttribute(
+            .font,
+            in: NSRange(location: 0, length: attributedString.length),
+            options: []
+        ) { value, _, stop in
+            if let font = value as? NSFont {
+                let fontName = font.fontName.lowercased()
+                if fontName.contains("menlo") ||
+                   fontName.contains("monaco") ||
+                   fontName.contains("courier") ||
+                   font.fontDescriptor.symbolicTraits.contains(.monoSpace) {
+                    found = true
+                    stop.pointee = true
+                }
+            }
+        }
+        return found
+    }
+
+    private func containsBackgroundColor(in attributedString: NSAttributedString) -> Bool {
+        var found = false
+        attributedString.enumerateAttribute(
+            .backgroundColor,
+            in: NSRange(location: 0, length: attributedString.length),
+            options: []
+        ) { value, _, stop in
+            if value != nil {
+                found = true
+                stop.pointee = true
+            }
+        }
+        return found
+    }
+
+    private func containsLinkAttribute(in attributedString: NSAttributedString) -> Bool {
+        var found = false
+        attributedString.enumerateAttribute(
+            .link,
+            in: NSRange(location: 0, length: attributedString.length),
+            options: []
+        ) { value, _, stop in
+            if value != nil {
+                found = true
+                stop.pointee = true
+            }
+        }
+        return found
+    }
+
+    private func containsForegroundColor(in attributedString: NSAttributedString) -> Bool {
+        var found = false
+        attributedString.enumerateAttribute(
+            .foregroundColor,
+            in: NSRange(location: 0, length: attributedString.length),
+            options: []
+        ) { value, _, stop in
+            if value != nil {
+                found = true
+                stop.pointee = true
+            }
+        }
+        return found
+    }
+
+    private func findMaxFontSize(in attributedString: NSAttributedString) -> CGFloat {
+        var maxSize: CGFloat = 0
+        attributedString.enumerateAttribute(
+            .font,
+            in: NSRange(location: 0, length: attributedString.length),
+            options: []
+        ) { value, _, _ in
+            if let font = value as? NSFont {
+                maxSize = max(maxSize, font.pointSize)
+            }
+        }
+        return maxSize
+    }
+
+    private func findAllFontSizes(in attributedString: NSAttributedString) -> Set<CGFloat> {
+        var sizes: Set<CGFloat> = []
+        attributedString.enumerateAttribute(
+            .font,
+            in: NSRange(location: 0, length: attributedString.length),
+            options: []
+        ) { value, _, _ in
+            if let font = value as? NSFont {
+                sizes.insert(font.pointSize)
+            }
+        }
+        return sizes
+    }
+}

--- a/RSSReaderTests/UnitTests/Utilities/HTMLAttributedStringConverterTests.swift
+++ b/RSSReaderTests/UnitTests/Utilities/HTMLAttributedStringConverterTests.swift
@@ -183,26 +183,25 @@ struct HTMLAttributedStringConverterTests {
 
     // MARK: - Whitespace Handling
 
-    @Test("Trims leading whitespace")
-    func trimsLeadingWhitespace() {
-        let html = "   \n  <p>Content starts here</p>"
+    @Test("Adds leading newline for spacing after header")
+    func addsLeadingNewline() {
+        let html = "<p>Content starts here</p>"
         let result = sut.convert(html)
 
         let string = result.string
-        #expect(!string.hasPrefix(" "), "Expected leading spaces to be trimmed")
-        #expect(!string.hasPrefix("\n"), "Expected leading newlines to be trimmed")
+        #expect(string.hasPrefix("\n"), "Expected leading newline for header spacing")
+        #expect(!string.hasPrefix("\n\n"), "Expected only one leading newline")
     }
 
-    @Test("Trims leading whitespace from content")
-    func trimsLeadingWhitespaceFromContent() {
-        let html = "\n\n   First line of content"
+    @Test("Normalizes excessive leading whitespace to single newline")
+    func normalizesLeadingWhitespace() {
+        let html = "   \n\n  <p>Content starts here</p>"
         let result = sut.convert(html)
 
         let string = result.string
-        #expect(
-            string.first?.isWhitespace == false,
-            "Expected first character to not be whitespace"
-        )
+        // Should have exactly one leading newline after normalization
+        #expect(string.hasPrefix("\n"), "Expected leading newline")
+        #expect(string.dropFirst().first != "\n", "Expected only one leading newline")
     }
 
     // MARK: - Nested Formatting

--- a/RSSReaderTests/UnitTests/ViewModels/ArticleDetailViewModelTests.swift
+++ b/RSSReaderTests/UnitTests/ViewModels/ArticleDetailViewModelTests.swift
@@ -195,4 +195,101 @@ struct ArticleDetailViewModelTests {
         let vm = ArticleDetailViewModel()
         #expect(!vm.showOpenedToast)
     }
+
+    // MARK: - Attributed Content
+
+    @Test("attributedContent returns non-empty for HTML content")
+    @MainActor
+    func attributedContentNonEmpty() {
+        let context = CoreDataTestHelper.makeContext()
+        let article = CDArticle.create(
+            in: context,
+            id: "a1",
+            title: "Test",
+            link: "https://example.com",
+            published: Date()
+        )
+        article.content = "<p>Hello <strong>world</strong></p>"
+
+        let vm = ArticleDetailViewModel()
+        let result = vm.attributedContent(for: article)
+        #expect(result.length > 0)
+        #expect(result.string.contains("Hello"))
+        #expect(result.string.contains("world"))
+    }
+
+    @Test("attributedContent sanitizes script tags")
+    @MainActor
+    func attributedContentSanitizes() {
+        let context = CoreDataTestHelper.makeContext()
+        let article = CDArticle.create(
+            in: context,
+            id: "a1",
+            title: "Test",
+            link: "https://example.com",
+            published: Date()
+        )
+        article.content = "<p>Safe</p><script>alert('xss')</script>"
+
+        let vm = ArticleDetailViewModel()
+        let result = vm.attributedContent(for: article)
+        #expect(!result.string.contains("alert"))
+        #expect(!result.string.contains("xss"))
+        #expect(result.string.contains("Safe"))
+    }
+
+    @Test("attributedContent returns empty for nil content")
+    @MainActor
+    func attributedContentEmpty() {
+        let context = CoreDataTestHelper.makeContext()
+        let article = CDArticle.create(
+            in: context,
+            id: "a1",
+            title: "Test",
+            link: "https://example.com",
+            published: Date()
+        )
+
+        let vm = ArticleDetailViewModel()
+        let result = vm.attributedContent(for: article)
+        #expect(result.length == 0)
+    }
+
+    @Test("attributedContent prefers content over summary")
+    @MainActor
+    func attributedContentPrefersContent() {
+        let context = CoreDataTestHelper.makeContext()
+        let article = CDArticle.create(
+            in: context,
+            id: "a1",
+            title: "Test",
+            link: "https://example.com",
+            published: Date()
+        )
+        article.content = "Full content"
+        article.summary = "Summary only"
+
+        let vm = ArticleDetailViewModel()
+        let result = vm.attributedContent(for: article)
+        #expect(result.string.contains("Full content"))
+        #expect(!result.string.contains("Summary only"))
+    }
+
+    @Test("attributedContent falls back to summary")
+    @MainActor
+    func attributedContentFallsBackToSummary() {
+        let context = CoreDataTestHelper.makeContext()
+        let article = CDArticle.create(
+            in: context,
+            id: "a1",
+            title: "Test",
+            link: "https://example.com",
+            published: Date()
+        )
+        article.summary = "Summary text here"
+
+        let vm = ArticleDetailViewModel()
+        let result = vm.attributedContent(for: article)
+        #expect(result.string.contains("Summary text here"))
+    }
 }


### PR DESCRIPTION
## Summary

- Implements rich text rendering for RSS article content with proper formatting for paragraphs, headings, bold/italic, blockquotes, code blocks, and lists
- Adds HTML sanitization to prevent XSS attacks by removing dangerous tags (script, style, iframe) and attributes (onclick, etc.)
- Creates NSViewRepresentable wrapper for NSTextView to display formatted content in SwiftUI

## Changes

### New Files
- `HTMLSanitizer.swift` - Allow-list based HTML sanitization service
- `HTMLAttributedStringConverter.swift` - Converts sanitized HTML to NSAttributedString with styling
- `RichTextView.swift` - NSViewRepresentable wrapper for NSTextView

### Modified Files
- `ArticleDetailViewModel.swift` - Added `attributedContent(for:)` method
- `ArticleDetailView.swift` - Replaced plain Text with RichTextView

### Tests
- `HTMLSanitizerTests.swift` - 35+ tests for sanitization logic
- `HTMLAttributedStringConverterTests.swift` - 20+ tests for conversion logic
- Updated `ArticleDetailViewModelTests.swift` with attributed content tests

## Test plan

- [x] All unit tests pass (`xcodebuild test`)
- [ ] Subscribe to feed with rich HTML content (e.g., Ars Technica)
- [ ] Verify paragraphs have visible gaps between them
- [ ] Verify bold/italic text renders correctly
- [ ] Verify headings are larger and bold
- [ ] Verify code blocks have monospace font
- [ ] Verify blockquotes are indented
- [ ] Verify lists have proper spacing
- [ ] Test text selection works
- [ ] Test links are clickable
- [ ] Test in light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)