### PR TITLE
Closes #107: Configure iCloud Sync Capabilities

### DIFF
--- a/RSSReader.xcodeproj/project.pbxproj
+++ b/RSSReader.xcodeproj/project.pbxproj
@@ -594,6 +594,11 @@
 				TargetAttributes = {
 					A5000001 = {
 						CreatedOnToolsVersion = 15.0;
+						SystemCapabilities = {
+							com.apple.iCloud = {
+								enabled = 1;
+							};
+						};
 					};
 					A5000002 = {
 						CreatedOnToolsVersion = 15.0;

--- a/RSSReader/RSSReader.entitlements
+++ b/RSSReader/RSSReader.entitlements
@@ -1,5 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>com.apple.developer.icloud-container-identifiers</key>
+	<array>
+		<string>iCloud.com.syndicate.app</string>
+	</array>
+	<key>com.apple.developer.icloud-services</key>
+	<array>
+		<string>CloudKit</string>
+	</array>
+	<key>com.apple.developer.ubiquity-kvstore-identifier</key>
+	<string>$(TeamIdentifierPrefix)com.syndicate.app</string>
+</dict>
 </plist>


### PR DESCRIPTION
## Summary
- Adds iCloud container identifier (`iCloud.com.syndicate.app`) to the entitlements file
- Enables CloudKit service for iCloud sync functionality
- Configures the Xcode project target with iCloud system capability
- Adds ubiquity key-value store identifier for future settings sync

## Manual Steps Required
After merging, the developer needs to:
1. **Apple Developer Portal**: Create an App ID with iCloud capabilities for `com.syndicate.app`
2. **CloudKit Container**: Create the `iCloud.com.syndicate.app` container in the CloudKit Dashboard
3. **Code Signing**: Configure signing with a valid development certificate in Xcode

## Test plan
- [x] Project builds successfully (without code signing)
- [x] All existing unit tests pass
- [ ] Manual: Verify iCloud capability appears in Xcode Signing & Capabilities
- [ ] Manual: Verify entitlements are correctly configured after code signing setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)