### PR TITLE
Closes #108: Refactor Persistence Layer for iCloud Sync

### DIFF
--- a/RSSReader/Services/PersistenceController.swift
+++ b/RSSReader/Services/PersistenceController.swift
@@ -5,25 +5,36 @@
 //  Created on 2026-01-29.
 //
 
+import CloudKit
 import CoreData
 import Foundation
 
-/// Manages the Core Data stack for local RSS data persistence.
+/// Manages the Core Data stack for local RSS data persistence with iCloud sync support.
 ///
 /// Provides both a main-thread `viewContext` for reads/UI binding
 /// and a factory method for background contexts used in write
 /// operations (feed refresh, article imports, cleanup).
+///
+/// When iCloud sync is enabled, uses `NSPersistentCloudKitContainer` to
+/// automatically sync data to the user's private CloudKit database.
 final class PersistenceController: @unchecked Sendable {
-    /// Shared instance for the app. Uses on-disk SQLite store.
+    /// Shared instance for the app. Uses on-disk SQLite store with iCloud sync.
     static let shared = PersistenceController()
 
     /// In-memory instance for SwiftUI previews and unit tests.
+    /// Does not sync to iCloud.
     static func inMemory() -> PersistenceController {
         PersistenceController(inMemory: true)
     }
 
-    /// The underlying persistent container.
-    let container: NSPersistentContainer
+    /// The iCloud container identifier for CloudKit sync.
+    static let cloudKitContainerIdentifier = "iCloud.com.syndicate.app"
+
+    /// Whether CloudKit sync is enabled for this controller.
+    let isCloudKitEnabled: Bool
+
+    /// The underlying persistent container with CloudKit support.
+    let container: NSPersistentCloudKitContainer
 
     /// Main-thread context for UI reads and light writes.
     var viewContext: NSManagedObjectContext {
@@ -51,15 +62,50 @@ final class PersistenceController: @unchecked Sendable {
 
     init(inMemory: Bool = false) {
         let model = CoreDataModel.makeModel()
-        container = NSPersistentContainer(
+        container = NSPersistentCloudKitContainer(
             name: "Syndicate",
             managedObjectModel: model
         )
 
         if inMemory {
+            // Create a fresh in-memory store description without any CloudKit config
             let description = NSPersistentStoreDescription()
             description.type = NSInMemoryStoreType
+            description.url = URL(fileURLWithPath: "/dev/null")
             container.persistentStoreDescriptions = [description]
+            isCloudKitEnabled = false
+        } else {
+            guard let description = container.persistentStoreDescriptions.first else {
+                fatalError("No persistent store descriptions found")
+            }
+
+            // Enable persistent history tracking for CloudKit sync
+            description.setOption(
+                true as NSNumber,
+                forKey: NSPersistentHistoryTrackingKey
+            )
+            description.setOption(
+                true as NSNumber,
+                forKey: NSPersistentStoreRemoteChangeNotificationPostOptionKey
+            )
+
+            // Check if CloudKit is available before enabling sync
+            // CloudKit requires:
+            // 1. A signed-in iCloud account
+            // 2. The app to be properly code-signed with iCloud entitlements
+            let cloudKitAvailable = Self.isCloudKitAvailable()
+
+            if cloudKitAvailable {
+                let cloudKitOptions = NSPersistentCloudKitContainerOptions(
+                    containerIdentifier: Self.cloudKitContainerIdentifier
+                )
+                description.cloudKitContainerOptions = cloudKitOptions
+                isCloudKitEnabled = true
+            } else {
+                // CloudKit not available - run in local-only mode
+                description.cloudKitContainerOptions = nil
+                isCloudKitEnabled = false
+            }
         }
 
         container.loadPersistentStores { _, error in
@@ -73,5 +119,33 @@ final class PersistenceController: @unchecked Sendable {
         container.viewContext.automaticallyMergesChangesFromParent = true
         container.viewContext.mergePolicy =
             NSMergeByPropertyObjectTrumpMergePolicy
+    }
+
+    // MARK: - CloudKit Availability
+
+    /// Checks if CloudKit is available for use.
+    ///
+    /// CloudKit requires the user to be signed into iCloud and the app
+    /// to be properly code-signed with iCloud entitlements.
+    private static func isCloudKitAvailable() -> Bool {
+        // Check if we're running in a test environment
+        if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil {
+            return false
+        }
+
+        // Check if iCloud is available by trying to access the container
+        let container = CKContainer(identifier: cloudKitContainerIdentifier)
+        var isAvailable = false
+
+        let semaphore = DispatchSemaphore(value: 0)
+        container.accountStatus { status, _ in
+            isAvailable = (status == .available)
+            semaphore.signal()
+        }
+
+        // Wait briefly for the check to complete (max 2 seconds)
+        _ = semaphore.wait(timeout: .now() + 2.0)
+
+        return isAvailable
     }
 }


### PR DESCRIPTION
## Summary
- Updates PersistenceController to use NSPersistentCloudKitContainer for iCloud sync support
- Configures persistent store with history tracking and remote change notifications
- Adds runtime CloudKit availability detection with graceful fallback to local-only mode
- Exposes isCloudKitEnabled property for UI status display (used in #110)

## Technical Details
- Container: NSPersistentCloudKitContainer replaces NSPersistentContainer
- History Tracking: Enabled via NSPersistentHistoryTrackingKey 
- Remote Notifications: Enabled via NSPersistentStoreRemoteChangeNotificationPostOptionKey
- Merge Policy: NSMergeByPropertyObjectTrumpMergePolicy (last-write-wins)
- CloudKit Check: Verifies iCloud account status before enabling sync

## CloudKit Availability Detection
The app gracefully handles scenarios where CloudKit is unavailable:
- Running without code signing (development/testing)
- User not signed into iCloud
- Running in test environment (XCTestConfigurationFilePath detection)

## Dependencies
- Requires: PR #112 (iCloud capabilities configuration)

## Test plan
- [x] All 70+ unit tests pass
- [x] Build succeeds with CloudKit availability check
- [ ] Manual: Verify iCloud sync works with proper code signing
- [ ] Manual: Verify app works in local-only mode when CloudKit unavailable

Generated with Claude Code