### PR TITLE
Closes #109: Migrate Data Model for iCloud Compatibility

### DIFF
--- a/RSSReader/Models/CDArticle.swift
+++ b/RSSReader/Models/CDArticle.swift
@@ -56,3 +56,79 @@ extension CDArticle {
         return article
     }
 }
+
+// MARK: - De-duplication (CloudKit Compatibility)
+
+extension CDArticle {
+    /// Checks if an article with the given ID already exists for a feed.
+    ///
+    /// This method performs an explicit fetch request to verify uniqueness,
+    /// which is required for CloudKit compatibility since Core Data unique
+    /// constraints are not supported.
+    ///
+    /// - Parameters:
+    ///   - articleId: The article ID to check for.
+    ///   - feed: The feed to check within.
+    ///   - context: The managed object context to use.
+    /// - Returns: The existing article if found, nil otherwise.
+    static func findExisting(
+        articleId: String,
+        feed: CDFeed,
+        in context: NSManagedObjectContext
+    ) -> CDArticle? {
+        let request = CDArticle.fetchRequest()
+        request.predicate = NSPredicate(
+            format: "id == %@ AND feed == %@",
+            articleId,
+            feed
+        )
+        request.fetchLimit = 1
+
+        do {
+            let results = try context.fetch(request)
+            return results.first
+        } catch {
+            return nil
+        }
+    }
+
+    /// Creates a new article only if one with the same ID doesn't exist for the feed.
+    ///
+    /// This method implements manual de-duplication for CloudKit compatibility.
+    /// Core Data's unique constraints are not supported with NSPersistentCloudKitContainer,
+    /// so we perform an explicit check before creating new articles.
+    ///
+    /// - Parameters:
+    ///   - context: The managed object context.
+    ///   - id: The unique article identifier.
+    ///   - title: The article title.
+    ///   - link: The article link.
+    ///   - published: The publication date.
+    ///   - feed: The feed this article belongs to.
+    /// - Returns: A tuple containing the article and whether it was newly created.
+    @discardableResult
+    static func createIfNotExists(
+        in context: NSManagedObjectContext,
+        id: String,
+        title: String,
+        link: String,
+        published: Date,
+        feed: CDFeed
+    ) -> (article: CDArticle, isNew: Bool) {
+        // Check for existing article with same ID in this feed
+        if let existing = findExisting(articleId: id, feed: feed, in: context) {
+            return (existing, false)
+        }
+
+        // No duplicate found, create new article
+        let article = create(
+            in: context,
+            id: id,
+            title: title,
+            link: link,
+            published: published,
+            feed: feed
+        )
+        return (article, true)
+    }
+}

--- a/RSSReader/Services/RefreshService.swift
+++ b/RSSReader/Services/RefreshService.swift
@@ -264,38 +264,33 @@ final class RefreshService: ObservableObject {
         }
 
         // Step 5: Persist new articles on context queue.
+        // Uses explicit fetch-based de-duplication for CloudKit compatibility.
         await context.perform {
             guard let feed = try? context
                 .existingObject(with: objectID) as? CDFeed
             else { return }
 
-            // Dedup by existing article IDs.
-            let existingIDs: Set<String>
-            if let articles = feed.articles
-                as? Set<CDArticle> {
-                existingIDs = Set(articles.map(\.id))
-            } else {
-                existingIDs = []
-            }
-
-            for parsed in parsedFeed.articles
-            where !existingIDs.contains(parsed.id) {
-                let article = CDArticle(
-                    context: context
+            for parsed in parsedFeed.articles {
+                // Use createIfNotExists for CloudKit-compatible de-duplication.
+                // This performs an explicit fetch request instead of relying on
+                // unique constraints (which CloudKit doesn't support).
+                let (article, isNew) = CDArticle.createIfNotExists(
+                    in: context,
+                    id: parsed.id,
+                    title: parsed.title,
+                    link: parsed.link.absoluteString,
+                    published: parsed.published,
+                    feed: feed
                 )
-                article.id = parsed.id
-                article.title = parsed.title
-                article.author = parsed.author
-                article.published = parsed.published
-                article.summary = parsed.summary
-                article.content = parsed.content
-                article.link =
-                    parsed.link.absoluteString
-                article.thumbnailURL =
-                    parsed.thumbnailURL?.absoluteString
-                article.isRead = false
-                article.dateAdded = Date()
-                article.feed = feed
+
+                // Only set additional properties for new articles
+                if isNew {
+                    article.author = parsed.author
+                    article.summary = parsed.summary
+                    article.content = parsed.content
+                    article.thumbnailURL =
+                        parsed.thumbnailURL?.absoluteString
+                }
             }
 
             feed.lastFetched = Date()

--- a/RSSReaderTests/UnitTests/Models/CDArticleTests.swift
+++ b/RSSReaderTests/UnitTests/Models/CDArticleTests.swift
@@ -161,4 +161,195 @@ struct CDArticleTests {
 
         #expect(feed.folder == nil)
     }
+
+    // MARK: - De-duplication (CloudKit Compatibility)
+
+    @Test("findExisting returns nil when no article exists")
+    func findExistingNoMatch() throws {
+        let context = CoreDataTestHelper.makeContext()
+        let feed = CDFeed.create(
+            in: context,
+            title: "Feed",
+            feedURL: "https://example.com/feed"
+        )
+        try context.save()
+
+        let result = CDArticle.findExisting(
+            articleId: "non-existent-id",
+            feed: feed,
+            in: context
+        )
+
+        #expect(result == nil)
+    }
+
+    @Test("findExisting returns existing article")
+    func findExistingMatch() throws {
+        let context = CoreDataTestHelper.makeContext()
+        let feed = CDFeed.create(
+            in: context,
+            title: "Feed",
+            feedURL: "https://example.com/feed"
+        )
+        let article = CDArticle.create(
+            in: context,
+            id: "article-123",
+            title: "Test Article",
+            link: "https://example.com/article",
+            published: Date(),
+            feed: feed
+        )
+        try context.save()
+
+        let result = CDArticle.findExisting(
+            articleId: "article-123",
+            feed: feed,
+            in: context
+        )
+
+        #expect(result === article)
+    }
+
+    @Test("findExisting does not match article in different feed")
+    func findExistingDifferentFeed() throws {
+        let context = CoreDataTestHelper.makeContext()
+        let feed1 = CDFeed.create(
+            in: context,
+            title: "Feed 1",
+            feedURL: "https://example.com/feed1"
+        )
+        let feed2 = CDFeed.create(
+            in: context,
+            title: "Feed 2",
+            feedURL: "https://example.com/feed2"
+        )
+        _ = CDArticle.create(
+            in: context,
+            id: "shared-id",
+            title: "Article in Feed 1",
+            link: "https://example.com/article",
+            published: Date(),
+            feed: feed1
+        )
+        try context.save()
+
+        // Same ID but different feed should not match
+        let result = CDArticle.findExisting(
+            articleId: "shared-id",
+            feed: feed2,
+            in: context
+        )
+
+        #expect(result == nil)
+    }
+
+    @Test("createIfNotExists creates new article when none exists")
+    func createIfNotExistsNew() throws {
+        let context = CoreDataTestHelper.makeContext()
+        let feed = CDFeed.create(
+            in: context,
+            title: "Feed",
+            feedURL: "https://example.com/feed"
+        )
+        try context.save()
+
+        let (article, isNew) = CDArticle.createIfNotExists(
+            in: context,
+            id: "new-article",
+            title: "New Article",
+            link: "https://example.com/new",
+            published: Date(),
+            feed: feed
+        )
+        try context.save()
+
+        #expect(isNew == true)
+        #expect(article.id == "new-article")
+        #expect(article.title == "New Article")
+
+        let request = CDArticle.fetchRequest()
+        let count = try context.count(for: request)
+        #expect(count == 1)
+    }
+
+    @Test("createIfNotExists returns existing article without creating duplicate")
+    func createIfNotExistsDuplicate() throws {
+        let context = CoreDataTestHelper.makeContext()
+        let feed = CDFeed.create(
+            in: context,
+            title: "Feed",
+            feedURL: "https://example.com/feed"
+        )
+        let existing = CDArticle.create(
+            in: context,
+            id: "existing-article",
+            title: "Original Title",
+            link: "https://example.com/original",
+            published: Date(),
+            feed: feed
+        )
+        try context.save()
+
+        // Try to create article with same ID
+        let (article, isNew) = CDArticle.createIfNotExists(
+            in: context,
+            id: "existing-article",
+            title: "Different Title",
+            link: "https://example.com/different",
+            published: Date(),
+            feed: feed
+        )
+
+        #expect(isNew == false)
+        #expect(article === existing)
+        #expect(article.title == "Original Title") // Not overwritten
+
+        let request = CDArticle.fetchRequest()
+        let count = try context.count(for: request)
+        #expect(count == 1) // Still only one article
+    }
+
+    @Test("createIfNotExists allows same ID in different feeds")
+    func createIfNotExistsSameIdDifferentFeeds() throws {
+        let context = CoreDataTestHelper.makeContext()
+        let feed1 = CDFeed.create(
+            in: context,
+            title: "Feed 1",
+            feedURL: "https://example.com/feed1"
+        )
+        let feed2 = CDFeed.create(
+            in: context,
+            title: "Feed 2",
+            feedURL: "https://example.com/feed2"
+        )
+
+        let (article1, isNew1) = CDArticle.createIfNotExists(
+            in: context,
+            id: "shared-id",
+            title: "Article in Feed 1",
+            link: "https://example.com/1",
+            published: Date(),
+            feed: feed1
+        )
+
+        let (article2, isNew2) = CDArticle.createIfNotExists(
+            in: context,
+            id: "shared-id",
+            title: "Article in Feed 2",
+            link: "https://example.com/2",
+            published: Date(),
+            feed: feed2
+        )
+        try context.save()
+
+        #expect(isNew1 == true)
+        #expect(isNew2 == true)
+        #expect(article1 !== article2)
+        #expect(article1.feed === feed1)
+        #expect(article2.feed === feed2)
+
+        let request = CDArticle.fetchRequest()
+        let count = try context.count(for: request)
+        #expect(count == 2)
+    }
 }


### PR DESCRIPTION
## Summary
- Implements manual de-duplication for articles (CloudKit does not support unique constraints)
- Adds CDArticle.findExisting() to check for existing articles by ID and feed
- Adds CDArticle.createIfNotExists() for safe article creation
- Updates RefreshService to use explicit fetch-based de-duplication
- Adds comprehensive unit tests for de-duplication logic (6 new tests)

## Technical Details
CloudKit does not support Core Data's uniqueConstraints. This PR implements manual de-duplication:
1. Before creating an article, fetch existing articles with same ID and feed
2. If found, return the existing article
3. If not found, create new article
4. This allows same article ID across different feeds (correct behavior)

## Dependencies
- Requires: PR #113 (persistence layer refactoring)

## Test plan
- [x] All unit tests pass (80+ tests)
- [x] De-duplication tests verify:
  - findExisting returns nil when no match
  - findExisting returns article when match exists
  - findExisting does not match article in different feed
  - createIfNotExists creates new article when none exists
  - createIfNotExists returns existing without creating duplicate
  - createIfNotExists allows same ID in different feeds

Generated with Claude Code